### PR TITLE
Finish the "ManageServerView" View

### DIFF
--- a/Nitrox.Launcher/DesignData.cs
+++ b/Nitrox.Launcher/DesignData.cs
@@ -11,5 +11,5 @@ public static class DesignData
 {
     public static MainWindowViewModel MainWindowViewModel { get; } = new();
     public static CreateServerViewModel CreateServerViewModel { get; } = new() { Name = "My Server Name", SelectedGameMode = GameMode.CREATIVE };
-    public static ManageServerViewModel ManageServerViewModel { get; } = new(null) { Server = new ServerEntry { Name = "My fun server" } };
+    public static ManageServerViewModel ManageServerViewModel { get; } = new(null) { ServerName = "My fun server" };
 }

--- a/Nitrox.Launcher/DesignData.cs
+++ b/Nitrox.Launcher/DesignData.cs
@@ -1,5 +1,6 @@
 using Nitrox.Launcher.Models;
 using Nitrox.Launcher.ViewModels;
+using Nitrox.Launcher.Views;
 
 namespace Nitrox.Launcher;
 
@@ -10,5 +11,5 @@ public static class DesignData
 {
     public static MainWindowViewModel MainWindowViewModel { get; } = new();
     public static CreateServerViewModel CreateServerViewModel { get; } = new() { Name = "My Server Name", SelectedGameMode = GameMode.CREATIVE };
-    public static ManageServerViewModel ManageServerViewModel { get; } = new(null) { ServerName = "My fun server" };
+    public static ManageServerViewModel ManageServerViewModel { get; } = new(null) { Server = new ServerEntry { Name = "My fun server" } };
 }

--- a/Nitrox.Launcher/Models/Converters/IntToStringConverter.cs
+++ b/Nitrox.Launcher/Models/Converters/IntToStringConverter.cs
@@ -20,7 +20,7 @@ public class IntToStringConverter : Converter<IntToStringConverter>, IValueConve
     {
         if (value == null)
         {
-            return "";
+            return 0;
         }
         string str = value as string ?? value.ToString();
 
@@ -29,6 +29,6 @@ public class IntToStringConverter : Converter<IntToStringConverter>, IValueConve
         {
             return result;
         }
-        return "";
+        return 0;
     }
 }

--- a/Nitrox.Launcher/Models/Converters/IntToStringConverter.cs
+++ b/Nitrox.Launcher/Models/Converters/IntToStringConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using Avalonia.Data;
+using Avalonia.Data.Converters;
+
+namespace Nitrox.Launcher.Models.Converters;
+
+/// <summary>
+///     Formats the bound value as a string from an integer.
+/// </summary>
+public class IntToStringConverter : Converter<IntToStringConverter>, IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return value.ToString();
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value == null)
+        {
+            return "";
+        }
+        string str = value as string ?? value.ToString();
+
+        str = Regex.Replace(str, "[^0-9]", "");
+        if (int.TryParse(str, out int result))
+        {
+            return result;
+        }
+        return "";
+    }
+}

--- a/Nitrox.Launcher/Models/Design/NitroxAttached.cs
+++ b/Nitrox.Launcher/Models/Design/NitroxAttached.cs
@@ -15,6 +15,7 @@ public class NitroxAttached : AvaloniaObject
 {
     public static readonly AttachedProperty<string> TextProperty = AvaloniaProperty.RegisterAttached<NitroxAttached, Interactive, string>("Text");
     public static readonly AttachedProperty<string> SubtextProperty = AvaloniaProperty.RegisterAttached<NitroxAttached, Interactive, string>("Subtext");
+    public static readonly AttachedProperty<string> ImageProperty = AvaloniaProperty.RegisterAttached<NitroxAttached, Interactive, string>("Image");
     public static readonly AttachedProperty<object> FocusProperty = AvaloniaProperty.RegisterAttached<NitroxAttached, Interactive, object>("Focus");
     public static readonly AttachedProperty<bool> SelectedProperty = AvaloniaProperty.RegisterAttached<NitroxAttached, Interactive, bool>("Selected");
     public static readonly AttachedProperty<ThemeOption> ThemeProperty = AvaloniaProperty.RegisterAttached<NitroxAttached, Interactive, ThemeOption>("Theme", inherits: true, defaultValue: ThemeOption.DARK);
@@ -45,6 +46,17 @@ public class NitroxAttached : AvaloniaObject
 
     public static string GetSubtext(AvaloniaObject element) => element.GetValue(SubtextProperty);
 
+    public static void SetImage(AvaloniaObject element, string value)
+    {
+        if (element is not Button)
+        {
+            throw new NotSupportedException($@"Attached property ""{nameof(ImageProperty)}"" is only supported on buttons.");
+        }
+        element.SetValue(ImageProperty, value);
+    }
+
+    public static string GetImage(AvaloniaObject element) => element.GetValue(ImageProperty);
+    
     public static object GetFocus(AvaloniaObject obj) => obj.GetValue(FocusProperty);
 
     /// <summary>

--- a/Nitrox.Launcher/Models/NitroxValidation.cs
+++ b/Nitrox.Launcher/Models/NitroxValidation.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Nitrox.Launcher.ViewModels;
 using ReactiveUI.Validation.Extensions;
 
@@ -19,8 +20,10 @@ public static class NitroxValidation
     {
         viewModel.ValidationRule(vm => vm.ServerName, IsNotNullAndWhiteSpace, $"{nameof(viewModel.ServerName)} shouldn't be empty.");
         viewModel.ValidationRule(vm => vm.ServerName, IsValidFileName, $"{nameof(viewModel.ServerName)} shouldn't contain invalid characters.");
+        viewModel.ValidationRule(vm => vm.ServerName, ContainsNoWhiteSpace, $"{nameof(viewModel.ServerSeed)} shouldn't contain any spaces.");
     }
 
     private static bool IsValidFileName(string s) => s == null || s.All(c => !invalidPathCharacters.Contains(c));
     private static bool IsNotNullAndWhiteSpace(string s) => !string.IsNullOrWhiteSpace(s);
+    private static bool ContainsNoWhiteSpace(string s) => !Regex.IsMatch(s, @"\s");
 }

--- a/Nitrox.Launcher/Models/NitroxValidation.cs
+++ b/Nitrox.Launcher/Models/NitroxValidation.cs
@@ -20,10 +20,12 @@ public static class NitroxValidation
     {
         viewModel.ValidationRule(vm => vm.ServerName, IsNotNullAndWhiteSpace, $"{nameof(viewModel.ServerName)} shouldn't be empty.");
         viewModel.ValidationRule(vm => vm.ServerName, IsValidFileName, $"{nameof(viewModel.ServerName)} shouldn't contain invalid characters.");
-        viewModel.ValidationRule(vm => vm.ServerName, ContainsNoWhiteSpace, $"{nameof(viewModel.ServerSeed)} shouldn't contain any spaces.");
+        viewModel.ValidationRule(vm => vm.ServerSeed, ContainsNoWhiteSpace, $"{nameof(viewModel.ServerSeed)} shouldn't contain any spaces.");
+        viewModel.ValidationRule(vm => vm.ServerSeed, IsProperSeed, $"{nameof(viewModel.ServerSeed)} should contain 10 alphabetical characters.");
     }
 
     private static bool IsValidFileName(string s) => s == null || s.All(c => !invalidPathCharacters.Contains(c));
     private static bool IsNotNullAndWhiteSpace(string s) => !string.IsNullOrWhiteSpace(s);
-    private static bool ContainsNoWhiteSpace(string s) => !Regex.IsMatch(s, @"\s");
+    private static bool ContainsNoWhiteSpace(string s) => s == null || !Regex.IsMatch(s, @"\s");
+    private static bool IsProperSeed(string s) => s == null || string.IsNullOrEmpty(s) || s.Length == 10 && Regex.IsMatch(s, @"^[a-zA-Z]+$");
 }

--- a/Nitrox.Launcher/Models/NitroxValidation.cs
+++ b/Nitrox.Launcher/Models/NitroxValidation.cs
@@ -17,8 +17,9 @@ public static class NitroxValidation
 
     public static void BindValidation(this ManageServerViewModel viewModel)
     {
-        viewModel.ValidationRule(vm => vm.ServerName, IsNotNullAndWhiteSpace, $"{nameof(viewModel.ServerName)} shouldn't be empty.");
-        viewModel.ValidationRule(vm => vm.ServerName, IsValidFileName, $"{nameof(viewModel.ServerName)} shouldn't contain invalid characters.");
+        // TODO: Fix these (they stopped working)
+        viewModel.ValidationRule(vm => vm.Server.Name, IsNotNullAndWhiteSpace, $"{nameof(viewModel.Server.Name)} shouldn't be empty.");
+        viewModel.ValidationRule(vm => vm.Server.Name, IsValidFileName, $"{nameof(viewModel.Server.Name)} shouldn't contain invalid characters.");
     }
 
     private static bool IsValidFileName(string s) => s == null || s.All(c => !invalidPathCharacters.Contains(c));

--- a/Nitrox.Launcher/Models/NitroxValidation.cs
+++ b/Nitrox.Launcher/Models/NitroxValidation.cs
@@ -22,10 +22,16 @@ public static class NitroxValidation
         viewModel.ValidationRule(vm => vm.ServerName, IsValidFileName, $"{nameof(viewModel.ServerName)} shouldn't contain invalid characters.");
         viewModel.ValidationRule(vm => vm.ServerSeed, ContainsNoWhiteSpace, $"{nameof(viewModel.ServerSeed)} shouldn't contain any spaces.");
         viewModel.ValidationRule(vm => vm.ServerSeed, IsProperSeed, $"{nameof(viewModel.ServerSeed)} should contain 10 alphabetical characters.");
+        viewModel.ValidationRule(vm => vm.ServerAutoSaveInterval, IsValidSaveInterval, $"{nameof(viewModel.ServerAutoSaveInterval)} should be between 10s and 24 hours (86400s).");
+        viewModel.ValidationRule(vm => vm.ServerMaxPlayers, IsValidPlayerLimit, $"{nameof(viewModel.ServerMaxPlayers)} should be greater than 0.");
+        viewModel.ValidationRule(vm => vm.ServerPort, IsValidPort, $"{nameof(viewModel.ServerPort)} should be between 0 and 65535");
     }
 
     private static bool IsValidFileName(string s) => s == null || s.All(c => !invalidPathCharacters.Contains(c));
     private static bool IsNotNullAndWhiteSpace(string s) => !string.IsNullOrWhiteSpace(s);
     private static bool ContainsNoWhiteSpace(string s) => s == null || !Regex.IsMatch(s, @"\s");
     private static bool IsProperSeed(string s) => s == null || string.IsNullOrEmpty(s) || s.Length == 10 && Regex.IsMatch(s, @"^[a-zA-Z]+$");
+    private static bool IsValidSaveInterval(int i) => i is >= 10 and <= 86400;
+    private static bool IsValidPlayerLimit(int i) => i > 0;
+    private static bool IsValidPort(int i) => i is >= 0 and <= 65535;
 }

--- a/Nitrox.Launcher/Models/NitroxValidation.cs
+++ b/Nitrox.Launcher/Models/NitroxValidation.cs
@@ -17,9 +17,8 @@ public static class NitroxValidation
 
     public static void BindValidation(this ManageServerViewModel viewModel)
     {
-        // TODO: Fix these (they stopped working)
-        viewModel.ValidationRule(vm => vm.Server.Name, IsNotNullAndWhiteSpace, $"{nameof(viewModel.Server.Name)} shouldn't be empty.");
-        viewModel.ValidationRule(vm => vm.Server.Name, IsValidFileName, $"{nameof(viewModel.Server.Name)} shouldn't contain invalid characters.");
+        viewModel.ValidationRule(vm => vm.ServerName, IsNotNullAndWhiteSpace, $"{nameof(viewModel.ServerName)} shouldn't be empty.");
+        viewModel.ValidationRule(vm => vm.ServerName, IsValidFileName, $"{nameof(viewModel.ServerName)} shouldn't contain invalid characters.");
     }
 
     private static bool IsValidFileName(string s) => s == null || s.All(c => !invalidPathCharacters.Contains(c));

--- a/Nitrox.Launcher/Models/PlayerPermissions.cs
+++ b/Nitrox.Launcher/Models/PlayerPermissions.cs
@@ -1,8 +1,14 @@
-﻿namespace Nitrox.Launcher.Models;
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Nitrox.Launcher.Models;
 
 public enum PlayerPermissions
 {
+    [Display(Name="Player")]
     PLAYER,
+    [Display(Name="Moderator")]
     MODERATOR,
+    [Display(Name="Admin")]
     ADMIN
 }

--- a/Nitrox.Launcher/Models/PlayerPermissions.cs
+++ b/Nitrox.Launcher/Models/PlayerPermissions.cs
@@ -1,0 +1,8 @@
+﻿namespace Nitrox.Launcher.Models;
+
+public enum PlayerPermissions
+{
+    PLAYER,
+    MODERATOR,
+    ADMIN
+}

--- a/Nitrox.Launcher/Models/PlayerPermissions.cs
+++ b/Nitrox.Launcher/Models/PlayerPermissions.cs
@@ -5,10 +5,7 @@ namespace Nitrox.Launcher.Models;
 
 public enum PlayerPermissions
 {
-    [Display(Name="Player")]
     PLAYER,
-    [Display(Name="Moderator")]
     MODERATOR,
-    [Display(Name="Admin")]
     ADMIN
 }

--- a/Nitrox.Launcher/Models/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/ServerEntry.cs
@@ -23,6 +23,7 @@ public class ServerEntry : ReactiveObject
     private bool autoPortForward = true;
     private bool allowLanDiscovery = true;
     private bool allowCommands = true;
+    private bool isNewServer = true;
     
     public bool IsOnline
     {
@@ -89,6 +90,13 @@ public class ServerEntry : ReactiveObject
         get => allowCommands;
         set => this.RaiseAndSetIfChanged(ref allowCommands, value);
     }
+
+    public bool IsNewServer
+    {
+        get => isNewServer;
+        private set => this.RaiseAndSetIfChanged(ref isNewServer, value);
+    }
+    
     public ICommand StartCommand { get; init; }
     public ICommand StopCommand { get; init; }
 
@@ -101,6 +109,8 @@ public class ServerEntry : ReactiveObject
     private Task StartServer()
     {
         IsOnline = true;
+        if (IsNewServer)
+            IsNewServer = false;
         return Task.CompletedTask;
     }
 

--- a/Nitrox.Launcher/Models/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/ServerEntry.cs
@@ -9,16 +9,20 @@ namespace Nitrox.Launcher.Models;
 /// </summary>
 public class ServerEntry : ReactiveObject
 {
+    // Default values
     private bool isOnline;
     private string name;
     private string password;
     private string seed;
-    private PlayerPermissions playerPermissions;
-    private int autoSaveInterval;
-    private int port;
-    private bool autoPortForward;
-    private bool allowLanDiscovery;
-    private bool allowCommands;
+    private GameMode gamemode = GameMode.SURVIVAL;
+    private PlayerPermissions playerPermissions = PlayerPermissions.PLAYER;
+    private int autoSaveInterval = 120;
+    private int players;
+    private int maxPlayers = 100;
+    private int port = 11000;
+    private bool autoPortForward = true;
+    private bool allowLanDiscovery = true;
+    private bool allowCommands = true;
     
     public bool IsOnline
     {
@@ -40,40 +44,51 @@ public class ServerEntry : ReactiveObject
         get => seed;
         set => this.RaiseAndSetIfChanged(ref seed, value);
     }
-    public GameMode GameMode { get; init; }
+    public GameMode GameMode
+    {
+        get => gamemode;
+        set => this.RaiseAndSetIfChanged(ref gamemode, value);
+    }
     public PlayerPermissions DefaultPlayerPerm
     {
-        get => playerPermissions = PlayerPermissions.PLAYER;
+        get => playerPermissions;
         set => this.RaiseAndSetIfChanged(ref playerPermissions, value);
     }
     public int AutoSaveInterval
     {
-        get => autoSaveInterval = 120;
+        get => autoSaveInterval;
         set => this.RaiseAndSetIfChanged(ref autoSaveInterval, value);
     }
-    public int Players { get; init; }
-    public int MaxPlayers { get; init; } = 100;
+    public int Players
+    {
+        get => players;
+        set => this.RaiseAndSetIfChanged(ref players, value);
+    }
+    public int MaxPlayers
+    {
+        get => maxPlayers;
+        set => this.RaiseAndSetIfChanged(ref maxPlayers, value);
+    }
     public int Port
     {
-        get => port = 11000;
+        get => port;
         set => this.RaiseAndSetIfChanged(ref port, value);
     }
     public bool AutoPortForward
     {
-        get => autoPortForward = true;
+        get => autoPortForward;
         set => this.RaiseAndSetIfChanged(ref autoPortForward, value);
     }
     public bool AllowLanDiscovery
     {
-        get => allowLanDiscovery = true;
+        get => allowLanDiscovery;
         set => this.RaiseAndSetIfChanged(ref allowLanDiscovery, value);
     }
     public bool AllowCommands
     {
-        get => allowCommands = true;
+        get => allowCommands;
         set => this.RaiseAndSetIfChanged(ref allowCommands, value);
     }
-    public string SavePath { get; init; }
     public ICommand StartCommand { get; init; }
     public ICommand StopCommand { get; init; }
     public ICommand ManageCommand { get; init; }

--- a/Nitrox.Launcher/Models/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/ServerEntry.cs
@@ -91,7 +91,6 @@ public class ServerEntry : ReactiveObject
     }
     public ICommand StartCommand { get; init; }
     public ICommand StopCommand { get; init; }
-    public ICommand ManageCommand { get; init; }
 
     public ServerEntry()
     {

--- a/Nitrox.Launcher/Models/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/ServerEntry.cs
@@ -9,7 +9,6 @@ namespace Nitrox.Launcher.Models;
 /// </summary>
 public class ServerEntry : ReactiveObject
 {
-    // Default values
     private bool isOnline;
     private string name;
     private string password;
@@ -24,7 +23,7 @@ public class ServerEntry : ReactiveObject
     private bool allowLanDiscovery = true;
     private bool allowCommands = true;
     private bool isNewServer = true;
-    
+
     public bool IsOnline
     {
         get => isOnline;
@@ -91,12 +90,15 @@ public class ServerEntry : ReactiveObject
         set => this.RaiseAndSetIfChanged(ref allowCommands, value);
     }
 
+    /// <summary>
+    /// TODO: This should be inferred from the server having a save file or not.
+    /// </summary>
     public bool IsNewServer
     {
         get => isNewServer;
         private set => this.RaiseAndSetIfChanged(ref isNewServer, value);
     }
-    
+
     public ICommand StartCommand { get; init; }
     public ICommand StopCommand { get; init; }
 

--- a/Nitrox.Launcher/Models/ServerEntry.cs
+++ b/Nitrox.Launcher/Models/ServerEntry.cs
@@ -11,22 +11,69 @@ public class ServerEntry : ReactiveObject
 {
     private bool isOnline;
     private string name;
-
-    public string Name
-    {
-        get => name;
-        set => this.RaiseAndSetIfChanged(ref name, value);
-    }
-
+    private string password;
+    private string seed;
+    private PlayerPermissions playerPermissions;
+    private int autoSaveInterval;
+    private int port;
+    private bool autoPortForward;
+    private bool allowLanDiscovery;
+    private bool allowCommands;
+    
     public bool IsOnline
     {
         get => isOnline;
         set => this.RaiseAndSetIfChanged(ref isOnline, value);
     }
-
+    public string Name
+    {
+        get => name;
+        set => this.RaiseAndSetIfChanged(ref name, value);
+    }
+    public string Password
+    {
+        get => password;
+        set => this.RaiseAndSetIfChanged(ref password, value);
+    }
+    public string Seed
+    {
+        get => seed;
+        set => this.RaiseAndSetIfChanged(ref seed, value);
+    }
     public GameMode GameMode { get; init; }
+    public PlayerPermissions DefaultPlayerPerm
+    {
+        get => playerPermissions = PlayerPermissions.PLAYER;
+        set => this.RaiseAndSetIfChanged(ref playerPermissions, value);
+    }
+    public int AutoSaveInterval
+    {
+        get => autoSaveInterval = 120;
+        set => this.RaiseAndSetIfChanged(ref autoSaveInterval, value);
+    }
     public int Players { get; init; }
     public int MaxPlayers { get; init; } = 100;
+    public int Port
+    {
+        get => port = 11000;
+        set => this.RaiseAndSetIfChanged(ref port, value);
+    }
+    public bool AutoPortForward
+    {
+        get => autoPortForward = true;
+        set => this.RaiseAndSetIfChanged(ref autoPortForward, value);
+    }
+    public bool AllowLanDiscovery
+    {
+        get => allowLanDiscovery = true;
+        set => this.RaiseAndSetIfChanged(ref allowLanDiscovery, value);
+    }
+    public bool AllowCommands
+    {
+        get => allowCommands = true;
+        set => this.RaiseAndSetIfChanged(ref allowCommands, value);
+    }
+    public string SavePath { get; init; }
     public ICommand StartCommand { get; init; }
     public ICommand StopCommand { get; init; }
     public ICommand ManageCommand { get; init; }

--- a/Nitrox.Launcher/Styles/Theme/ButtonStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ButtonStyle.axaml
@@ -141,6 +141,10 @@
                 <Setter Property="TextDecorations" Value="Underline" />
             </Style>
         </Style>
+        
+        <Style Selector="^:disabled /template/ ContentPresenter">
+            <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
+        </Style>
     </Style>
     
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/ButtonStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ButtonStyle.axaml
@@ -1,7 +1,8 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design">
-    <Design.PreviewWith>
+        xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design"
+        xmlns:converters="clr-namespace:Nitrox.Launcher.Models.Converters">
+    <Design.PreviewWith> <!-- Previewer broken - see Ref 1 further down in this file  -->
         <Panel Background="Cornflowerblue">
             <StackPanel Margin="10" Spacing="10">
                 <StackPanel design:NitroxAttached.Theme="LIGHT" HorizontalAlignment="Center">
@@ -13,6 +14,20 @@
                     <Button Classes="nitrox" design:NitroxAttached.Text="Normal button" HorizontalAlignment="Stretch" />
                     <Button Classes="nitrox primary" design:NitroxAttached.Text="Primary button" HorizontalAlignment="Stretch" />
                     <Button Classes="nitrox primary big" design:NitroxAttached.Text="Primary Button Big" design:NitroxAttached.Subtext="Some sub text" />
+                </StackPanel>
+                <StackPanel>
+                    <Border design:NitroxAttached.Theme="LIGHT" HorizontalAlignment="Stretch" Background="White" Padding="10">
+                        <Button Classes="textimage"
+                                design:NitroxAttached.Image="/Assets/Images/world-manager/cog-2x.png"
+                                design:NitroxAttached.Text="Text Image button"
+                                HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border design:NitroxAttached.Theme="DARK" HorizontalAlignment="Stretch" Background="Black" Padding="10">
+                        <Button Classes="textimage"
+                                design:NitroxAttached.Image="/Assets/Images/world-manager/cog-2x.png"
+                                design:NitroxAttached.Text="Text Image button"
+                                HorizontalAlignment="Center"/>
+                    </Border>
                 </StackPanel>
             </StackPanel>
         </Panel>
@@ -86,4 +101,46 @@
             <Setter Property="FontWeight" Value="600" />
         </Style>
     </Style>
+    
+    <Style Selector="Button.textimage">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="CornerRadius" Value="4" />
+        <Setter Property="Content">
+            <Setter.Value>
+                <Template>
+                    <Grid ColumnDefinitions="Auto,*" VerticalAlignment="Center" HorizontalAlignment="Stretch">
+                        <Viewbox>
+                            <!-- Ref 1 - The converter here somehow breaks the previewer, but is needed to show the image for the control -->
+                            <Image Source="{Binding (design:NitroxAttached.Image), Converter={converters:BitmapAssetValueConverter}, RelativeSource={RelativeSource AncestorType=Button}}"
+                                   HorizontalAlignment="Center" Width="18" Height="18"/>
+                        </Viewbox>
+                        <TextBlock Grid.Column="1" x:Name="ButtonText"
+                                   Foreground="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}"
+                                   Text="{Binding (design:NitroxAttached.Text), RelativeSource={RelativeSource AncestorType=Button}}"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center" Margin="8 0 0 0"/>
+                    </Grid>
+                </Template>
+            </Setter.Value>
+        </Setter>
+
+        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
+            <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
+        </Style>
+        <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
+            <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
+        </Style>
+        
+        <Style Selector="^:pointerover">
+            <Style Selector="^ /template/ ContentPresenter">
+                <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
+                <Setter Property="Cursor" Value="Hand"/>
+            </Style>
+            
+            <Style Selector="^ TextBlock">
+                <Setter Property="TextDecorations" Value="Underline" />
+            </Style>
+        </Style>
+    </Style>
+    
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/ButtonStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ButtonStyle.axaml
@@ -89,6 +89,13 @@
     <Style Selector="Button.abort">
         <Setter Property="Background" Value="{DynamicResource BrandAbortBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
+        
+        <Style Selector="^:disabled /template/ ContentPresenter">
+            <!-- TODO: Nice disabled style (loading indicator?) -->
+            <Setter Property="TextBlock.Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=Button}}" />
+            <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
+            <Setter Property="Opacity" Value="0.15" />
+        </Style>
     </Style>
 
     <Style Selector="Button.big">

--- a/Nitrox.Launcher/Styles/Theme/CheckBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/CheckBoxStyle.axaml
@@ -1,0 +1,132 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design">
+    <Design.PreviewWith>
+        <Panel Background="CornflowerBlue">
+            <StackPanel Margin="10" Spacing="15">
+                <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+                    <Border Background="White" design:NitroxAttached.Theme="LIGHT" Padding="5">
+                        <CheckBox>Light</CheckBox>
+                    </Border>
+                    <Border Background="Black" design:NitroxAttached.Theme="DARK" Padding="5">
+                        <CheckBox IsChecked="True" Foreground="White">Dark</CheckBox>
+                    </Border>
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+                    <Border Background="White" design:NitroxAttached.Theme="LIGHT" Padding="5">
+                        <CheckBox Classes="switch"/>
+                    </Border>
+                    <Border Background="Black" design:NitroxAttached.Theme="DARK" Padding="5">
+                        <CheckBox Classes="switch" IsChecked="True" Foreground="White"/>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+        </Panel>
+    </Design.PreviewWith>
+    
+    <Style Selector="CheckBox.switch">
+        
+        <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
+            <Setter Property="Background" Value="#333333" />
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
+            <Setter Property="Background" Value="#d9d9d9" />
+            <Setter Property="Foreground" Value="#3b3b3b" />
+        </Style>
+        
+        <Setter Property="CornerRadius" Value="15" />
+        <Setter Property="Height" Value="30" />
+        <Setter Property="Width" Value="54" />
+        
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid x:Name="RootGrid">
+                    <Border x:Name="PART_Border" Padding="4"
+                            Background="{TemplateBinding Background}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                        <Viewbox x:Name="SlidingIconViewbox" HorizontalAlignment="Left">
+                            <Border x:Name="SlidingIcon" Width="24" Height="24" CornerRadius="15" Background="{TemplateBinding Foreground}">
+                                <Border.Styles>
+                                    <Style Selector="Border">
+                                        <Setter Property="Transitions">
+                                            <Transitions>
+                                                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
+                                                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+                                            </Transitions>
+                                        </Setter>
+                                    </Style>
+                                </Border.Styles>
+                            </Border>
+                        </Viewbox>    
+                    </Border>
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+        
+        <!-- Unchecked PointerOver State -->
+        <Style Selector="^:pointerover">
+            <Setter Property="Cursor" Value="Hand"/>
+        
+            <Style Selector="^ /template/ Border#PART_Border">
+                <Setter Property="Background" Value="{TemplateBinding Background}" />
+            </Style>
+            
+            <Style Selector="^ /template/ Border#SlidingIcon">
+                <Setter Property="Opacity" Value=".75" />
+            </Style>
+        </Style>
+    
+        <!-- Unchecked Pressed State -->
+        <Style Selector="^:pressed">
+            <Style Selector="^ /template/ Border#PART_Border">
+                <Setter Property="Background" Value="{TemplateBinding Background}" />
+            </Style>
+            
+            <Style Selector="^ /template/ Border#SlidingIcon">
+                <Setter Property="RenderTransform" Value="scale(0.95)" />
+            </Style>
+        </Style>
+        
+        <Style Selector="^:checked">
+            
+            <!-- Checked Normal State -->
+            <Setter Property="Background" Value="{TemplateBinding Background}" />
+            
+            <Style Selector="^ /template/ Border#SlidingIcon">
+                <Setter Property="Background" Value="#007BFF" />
+            </Style>
+            
+            <Style Selector="^ /template/ Viewbox#SlidingIconViewbox">
+                <Setter Property="HorizontalAlignment" Value="Right" />
+            </Style>
+            
+            <!-- Checked PointerOver State -->
+            <Style Selector="^:pointerover">
+                <Setter Property="Cursor" Value="Hand"/>
+                
+                <Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{TemplateBinding Background}" />
+                </Style>
+                
+                <Style Selector="^ /template/ Border#SlidingIcon">
+                    <Setter Property="Opacity" Value=".75" />
+                </Style>
+            </Style>
+        
+            <!-- Checked Pressed State -->
+            <Style Selector="^:pressed">
+                <Style Selector="^ /template/ Border#PART_Border">
+                    <Setter Property="Background" Value="{TemplateBinding Background}" />
+                </Style>
+                
+                <Style Selector="^ /template/ Border#SlidingIcon">
+                    <Setter Property="RenderTransform" Value="scale(0.95)" />
+                </Style>
+            </Style>
+            
+        </Style>
+        
+    </Style>
+    
+</Styles>

--- a/Nitrox.Launcher/Styles/Theme/CheckBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/CheckBoxStyle.axaml
@@ -88,6 +88,11 @@
             </Style>
         </Style>
         
+        <!-- Disabled State -->
+        <Style Selector="^:disabled /template/ Border#PART_Border">
+            <Setter Property="Background" Value="{TemplateBinding Background}" />
+        </Style>
+        
         <Style Selector="^:checked">
             
             <!-- Checked Normal State -->

--- a/Nitrox.Launcher/Styles/Theme/CheckBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/CheckBoxStyle.axaml
@@ -14,18 +14,18 @@
                 </StackPanel>
                 <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
                     <Border Background="White" design:NitroxAttached.Theme="LIGHT" Padding="5">
-                        <CheckBox Classes="switch"/>
+                        <CheckBox Classes="switch" />
                     </Border>
                     <Border Background="Black" design:NitroxAttached.Theme="DARK" Padding="5">
-                        <CheckBox Classes="switch" IsChecked="True" Foreground="White"/>
+                        <CheckBox Classes="switch" IsChecked="True" Foreground="White" />
                     </Border>
                 </StackPanel>
             </StackPanel>
         </Panel>
     </Design.PreviewWith>
-    
+
     <Style Selector="CheckBox.switch">
-        
+
         <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
             <Setter Property="Background" Value="#333333" />
             <Setter Property="Foreground" Value="White" />
@@ -34,11 +34,11 @@
             <Setter Property="Background" Value="#d9d9d9" />
             <Setter Property="Foreground" Value="#3b3b3b" />
         </Style>
-        
+
         <Setter Property="CornerRadius" Value="15" />
         <Setter Property="Height" Value="30" />
         <Setter Property="Width" Value="54" />
-        
+
         <Setter Property="Template">
             <ControlTemplate>
                 <Grid x:Name="RootGrid">
@@ -53,85 +53,83 @@
                                             <Transitions>
                                                 <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
                                                 <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+                                                <ThicknessTransition Property="Margin" Duration="0:0:0.1" />
                                             </Transitions>
                                         </Setter>
                                     </Style>
                                 </Border.Styles>
                             </Border>
-                        </Viewbox>    
+                        </Viewbox>
                     </Border>
                 </Grid>
             </ControlTemplate>
         </Setter>
-        
+
         <!-- Unchecked PointerOver State -->
         <Style Selector="^:pointerover">
-            <Setter Property="Cursor" Value="Hand"/>
-        
+            <Setter Property="Cursor" Value="Hand" />
+
             <Style Selector="^ /template/ Border#PART_Border">
                 <Setter Property="Background" Value="{TemplateBinding Background}" />
             </Style>
-            
+
             <Style Selector="^ /template/ Border#SlidingIcon">
                 <Setter Property="Opacity" Value=".75" />
             </Style>
         </Style>
-    
+
         <!-- Unchecked Pressed State -->
         <Style Selector="^:pressed">
             <Style Selector="^ /template/ Border#PART_Border">
                 <Setter Property="Background" Value="{TemplateBinding Background}" />
             </Style>
-            
+
             <Style Selector="^ /template/ Border#SlidingIcon">
                 <Setter Property="RenderTransform" Value="scale(0.95)" />
             </Style>
         </Style>
-        
+
         <!-- Disabled State -->
         <Style Selector="^:disabled /template/ Border#PART_Border">
             <Setter Property="Background" Value="{TemplateBinding Background}" />
         </Style>
-        
+
         <Style Selector="^:checked">
-            
+
             <!-- Checked Normal State -->
             <Setter Property="Background" Value="{TemplateBinding Background}" />
-            
+
             <Style Selector="^ /template/ Border#SlidingIcon">
                 <Setter Property="Background" Value="#007BFF" />
+                <Setter Property="Margin" Value="22 0 0 0" />
             </Style>
-            
-            <Style Selector="^ /template/ Viewbox#SlidingIconViewbox">
-                <Setter Property="HorizontalAlignment" Value="Right" />
-            </Style>
-            
+
             <!-- Checked PointerOver State -->
             <Style Selector="^:pointerover">
-                <Setter Property="Cursor" Value="Hand"/>
-                
+                <Setter Property="Cursor" Value="Hand" />
+
                 <Style Selector="^ /template/ Border#PART_Border">
                     <Setter Property="Background" Value="{TemplateBinding Background}" />
                 </Style>
-                
+
                 <Style Selector="^ /template/ Border#SlidingIcon">
                     <Setter Property="Opacity" Value=".75" />
                 </Style>
             </Style>
-        
+
             <!-- Checked Pressed State -->
             <Style Selector="^:pressed">
                 <Style Selector="^ /template/ Border#PART_Border">
                     <Setter Property="Background" Value="{TemplateBinding Background}" />
                 </Style>
-                
+
                 <Style Selector="^ /template/ Border#SlidingIcon">
                     <Setter Property="RenderTransform" Value="scale(0.95)" />
                 </Style>
             </Style>
-            
+
         </Style>
-        
+
     </Style>
-    
+
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
@@ -1,0 +1,159 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design">
+    <Design.PreviewWith>
+        <Panel Background="CornflowerBlue">
+            <StackPanel Margin="10" Spacing="10">
+                <StackPanel HorizontalAlignment="Center">
+                    <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
+                        <ComboBox PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
+                            <ComboBoxItem Content="Item 1"/>
+                            <ComboBoxItem Content="Item 2"/>
+                            <ComboBoxItem Content="Item 3"/>
+                        </ComboBox>
+                    </Border>
+                    
+                </StackPanel>
+                <StackPanel HorizontalAlignment="Center">
+                    <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
+                        <ComboBox PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
+                            <ComboBoxItem Content="Item 1"/>
+                            <ComboBoxItem Content="Item 2"/>
+                            <ComboBoxItem Content="Item 3"/>
+                        </ComboBox>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+        </Panel>
+    </Design.PreviewWith>
+    
+    <Style Selector="ComboBox">
+        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="14" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="true"/> <!-- This one may be bad -->
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="MinWidth" Value="100"/>
+        <Setter Property="MinHeight" Value="30"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DataValidationErrors>
+                    <Grid>
+                        
+                        <Button HorizontalAlignment="Stretch" Padding="0" Background="Transparent" CornerRadius="8" BorderThickness="0">
+                            <Grid ColumnDefinitions="*,32" IsHitTestVisible="True">
+                                <Border x:Name="Background"
+                                        Grid.ColumnSpan="2"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{TemplateBinding CornerRadius}"
+                                        MinWidth="{DynamicResource ComboBoxThemeMinWidth}" />
+                                <TextBlock Grid.Column="0" x:Name="PlaceholderTextBlock"
+                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                           Margin="{TemplateBinding Padding}"
+                                           Text="{TemplateBinding PlaceholderText}"
+                                           IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
+                                <ContentControl Grid.Column="0" x:Name="ContentPresenter"
+                                                Content="{TemplateBinding SelectionBoxItem}"
+                                                ContentTemplate="{TemplateBinding ItemTemplate}"
+                                                Margin="{TemplateBinding Padding}"
+                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                                <Border x:Name="DropDownOverlay"
+                                        Grid.Column="1"
+                                        Background="Transparent"
+                                        Margin="0,1,1,1"
+                                        Width="30"
+                                        IsVisible="False"
+                                        HorizontalAlignment="Right" />
+                                <PathIcon x:Name="DropDownGlyph"
+                                          Grid.Column="1"
+                                          UseLayoutRounding="False"
+                                          IsHitTestVisible="False"
+                                          Height="12" Width="12"
+                                          Margin="0,0,10,0"
+                                          HorizontalAlignment="Right"
+                                          VerticalAlignment="Center"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          Data="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z"/>
+                            </Grid>
+                        </Button>
+                        
+                        <Popup Grid.Column="0" Name="PART_Popup"
+                               WindowManagerAddShadowHint="False"
+                               IsOpen="{TemplateBinding IsDropDownOpen, Mode=TwoWay}"
+                               MinWidth="{Binding Bounds.Width, RelativeSource={RelativeSource TemplatedParent}}"
+                               MaxHeight="{TemplateBinding MaxDropDownHeight}"
+                               PlacementTarget="Background"
+                               IsLightDismissEnabled="True"
+                               InheritsTransform="True">
+                            <Border x:Name="PopupBorder"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{DynamicResource ComboBoxDropDownBorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    Padding="{DynamicResource ComboBoxDropdownBorderPadding}"
+                                    HorizontalAlignment="Stretch"
+                                    CornerRadius="{DynamicResource OverlayCornerRadius}">
+                                <ScrollViewer HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                                              VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}">
+                                    <ItemsPresenter Name="PART_ItemsPresenter"
+                                                    Margin="{DynamicResource ComboBoxDropdownContentMargin}"
+                                                    ItemsPanel="{TemplateBinding ItemsPanel}" />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                        
+                    </Grid>
+                </DataValidationErrors>
+            </ControlTemplate>
+        </Setter>
+
+        
+        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
+            <Setter Property="Background" Value="#ECECEC" />
+            <Setter Property="PlaceholderForeground" Value="#0f0f0f" />
+            <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#Background">
+                <Setter Property="Background" Value="#ECECEC" />
+                <Setter Property="Opacity" Value=".6" />
+            </Style>
+        </Style>
+        <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
+            <Setter Property="Background" Value="#1F1F1F" />
+            <Setter Property="PlaceholderForeground" Value="#f0f0f0" />
+            <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#Background">
+                <Setter Property="Background" Value="#1F1F1F" />
+                <Setter Property="Opacity" Value=".6" />
+            </Style>
+        </Style>
+        
+        <Style Selector="^ /template/ Border#Background">
+            <Setter Property="Opacity" Value="1"/>
+            <Setter Property="Transitions">
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+                </Transitions>
+            </Setter>
+        </Style>
+        
+        <Style Selector="^:pointerover /template/ Border#Background">
+            
+        </Style>
+        
+    </Style>
+    
+</Styles>

--- a/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
@@ -6,16 +6,17 @@
             <StackPanel Margin="10" Spacing="10">
                 <StackPanel HorizontalAlignment="Center">
                     <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
+                        <!-- (TODO) The ComboBox item highlight shows correctly in the Previewer, but not in-app. The foreground also looks wrong, but it shows correctly in-app  -->
                         <ComboBox PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
                             <ComboBoxItem Content="Item 1"/>
                             <ComboBoxItem Content="Item 2"/>
                             <ComboBoxItem Content="Item 3"/>
                         </ComboBox>
                     </Border>
-                    
                 </StackPanel>
                 <StackPanel HorizontalAlignment="Center">
                     <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
+                        <!-- The ComboBox item highlight DOESN'T show correctly in the Previewer, but it DOES in-app -->
                         <ComboBox PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
                             <ComboBoxItem Content="Item 1"/>
                             <ComboBoxItem Content="Item 2"/>
@@ -40,51 +41,56 @@
         <Setter Property="CornerRadius" Value="8" />
         <Setter Property="MinWidth" Value="100"/>
         <Setter Property="MinHeight" Value="30"/>
+        
+        <Setter Property="Transitions">
+            <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
+                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+            </Transitions>
+        </Setter>
+        
         <Setter Property="Template">
             <ControlTemplate>
                 <DataValidationErrors>
                     <Grid>
-                        
-                        <Button HorizontalAlignment="Stretch" Padding="0" Background="Transparent" CornerRadius="8" BorderThickness="0">
-                            <Grid ColumnDefinitions="*,32" IsHitTestVisible="True">
-                                <Border x:Name="Background"
-                                        Grid.ColumnSpan="2"
-                                        Background="{TemplateBinding Background}"
-                                        BorderBrush="{TemplateBinding BorderBrush}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        CornerRadius="{TemplateBinding CornerRadius}"
-                                        MinWidth="{DynamicResource ComboBoxThemeMinWidth}" />
-                                <TextBlock Grid.Column="0" x:Name="PlaceholderTextBlock"
-                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                           Margin="{TemplateBinding Padding}"
-                                           Text="{TemplateBinding PlaceholderText}"
-                                           IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
-                                <ContentControl Grid.Column="0" x:Name="ContentPresenter"
-                                                Content="{TemplateBinding SelectionBoxItem}"
-                                                ContentTemplate="{TemplateBinding ItemTemplate}"
-                                                Margin="{TemplateBinding Padding}"
-                                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-                                <Border x:Name="DropDownOverlay"
-                                        Grid.Column="1"
-                                        Background="Transparent"
-                                        Margin="0,1,1,1"
-                                        Width="30"
-                                        IsVisible="False"
-                                        HorizontalAlignment="Right" />
-                                <PathIcon x:Name="DropDownGlyph"
-                                          Grid.Column="1"
-                                          UseLayoutRounding="False"
-                                          IsHitTestVisible="False"
-                                          Height="12" Width="12"
-                                          Margin="0,0,10,0"
-                                          HorizontalAlignment="Right"
-                                          VerticalAlignment="Center"
-                                          Foreground="{TemplateBinding Foreground}"
-                                          Data="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z"/>
-                            </Grid>
-                        </Button>
+                        <Grid ColumnDefinitions="*,32" IsHitTestVisible="True">
+                            <Border x:Name="Background"
+                                    Grid.ColumnSpan="2"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}"
+                                    CornerRadius="{TemplateBinding CornerRadius}"
+                                    MinWidth="{DynamicResource ComboBoxThemeMinWidth}" />
+                            <TextBlock Grid.Column="0" x:Name="PlaceholderTextBlock"
+                                       HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                       VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                       Margin="{TemplateBinding Padding}"
+                                       Text="{TemplateBinding PlaceholderText}"
+                                       IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
+                            <ContentControl Grid.Column="0" x:Name="ContentPresenter" Foreground="Blue"
+                                            Content="{TemplateBinding SelectionBoxItem}"
+                                            ContentTemplate="{TemplateBinding ItemTemplate}"
+                                            Margin="{TemplateBinding Padding}"
+                                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+                            <Border x:Name="DropDownOverlay"
+                                    Grid.Column="1"
+                                    Background="Transparent"
+                                    Margin="0,1,1,1"
+                                    Width="30"
+                                    IsVisible="False"
+                                    HorizontalAlignment="Right" />
+                            <PathIcon x:Name="DropDownGlyph"
+                                      Grid.Column="1"
+                                      UseLayoutRounding="False"
+                                      IsHitTestVisible="False"
+                                      Height="12" Width="12"
+                                      Margin="0,0,10,0"
+                                      HorizontalAlignment="Right"
+                                      VerticalAlignment="Center"
+                                      Foreground="{TemplateBinding Foreground}"
+                                      Data="M1939 486L2029 576L1024 1581L19 576L109 486L1024 1401L1939 486Z"/>
+                        </Grid>
                         
                         <Popup Grid.Column="0" Name="PART_Popup"
                                WindowManagerAddShadowHint="False"
@@ -114,46 +120,48 @@
                 </DataValidationErrors>
             </ControlTemplate>
         </Setter>
-
         
-        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
-            <Setter Property="Background" Value="#ECECEC" />
-            <Setter Property="PlaceholderForeground" Value="#0f0f0f" />
-            <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
-            <Style Selector="^ /template/ TextBlock">
-                <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
-            </Style>
-            <Style Selector="^:pointerover /template/ Border#Background">
-                <Setter Property="Background" Value="#ECECEC" />
-                <Setter Property="Opacity" Value=".6" />
-            </Style>
-        </Style>
         <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
             <Setter Property="Background" Value="#1F1F1F" />
-            <Setter Property="PlaceholderForeground" Value="#f0f0f0" />
-            <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
             <Style Selector="^ /template/ TextBlock">
                 <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
             </Style>
+            <Style Selector="^ /template/ PathIcon">
+                <Setter Property="Foreground" Value="{DynamicResource BrandWhiteBrush}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="Foreground" Value="#80FFFFFF" />
+            </Style>
             <Style Selector="^:pointerover /template/ Border#Background">
                 <Setter Property="Background" Value="#1F1F1F" />
-                <Setter Property="Opacity" Value=".6" />
+            </Style>
+        </Style>
+        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
+            <Setter Property="Background" Value="#ECECEC" />
+            <Style Selector="^ /template/ TextBlock">
+                <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
+            </Style>
+            <Style Selector="^ /template/ PathIcon">
+                <Setter Property="Foreground" Value="{DynamicResource BrandBlackBrush}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#PlaceholderTextBlock">
+                <Setter Property="Foreground" Value="#202225" />
+            </Style>
+            <Style Selector="^:pointerover /template/ Border#Background">
+                <Setter Property="Background" Value="#ECECEC" />
             </Style>
         </Style>
         
-        <Style Selector="^ /template/ Border#Background">
-            <Setter Property="Opacity" Value="1"/>
-            <Setter Property="Transitions">
-                <Transitions>
-                    <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
-                </Transitions>
-            </Setter>
+        <Style Selector="^:pointerover">
+            <Setter Property="Opacity" Value=".75" />
         </Style>
         
-        <Style Selector="^:pointerover /template/ Border#Background">
-            
+        <Style Selector="^:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.98)" />
         </Style>
         
     </Style>
+    
+    
     
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
@@ -26,30 +26,7 @@
                         </Border>
                     </Border>
                 </StackPanel>
-                
-                <StackPanel Spacing="10">
-                    <Border Background="White" Padding="10" HorizontalAlignment="Center">
-                        <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
-                            <ComboBox Classes="text" PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
-                                <ComboBoxItem Content="Item 1"/>
-                                <ComboBoxItem Content="Item 2"/>
-                                <ComboBoxItem Content="Item 3"/>
-                            </ComboBox>
-                        </Border>
-                    </Border>
-                    <Border Background="Black" Padding="10" HorizontalAlignment="Center">
-                        <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
-                            <ComboBox Classes="text" PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
-                                <ComboBoxItem Content="Item 1"/>
-                                <ComboBoxItem Content="Item 2"/>
-                                <ComboBoxItem Content="Item 3"/>
-                            </ComboBox>
-                        </Border>
-                    </Border>
-                </StackPanel>
             </StackPanel>
-            
-            
         </Panel>
     </Design.PreviewWith>
     
@@ -190,13 +167,5 @@
         </Style>
         
     </Style>
-    
-    <!--Style Selector="ComboBox.text">
-        <Style Selector="ComboBox /template/ ContentControl">
-            <Setter Property="Content">
-                <ItemTe
-            </Setter>
-        </Style>
-    </Style-->
     
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
@@ -4,7 +4,7 @@
     <Design.PreviewWith>
         <Panel Background="CornflowerBlue">
             <StackPanel Margin="10" Spacing="10">
-                <StackPanel HorizontalAlignment="Center">
+                <Border Background="White" Padding="10" HorizontalAlignment="Center">
                     <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
                         <!-- (TODO) The ComboBox item highlight shows correctly in the Previewer, but not in-app. The foreground also looks wrong, but it shows correctly in-app  -->
                         <ComboBox PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
@@ -13,8 +13,8 @@
                             <ComboBoxItem Content="Item 3"/>
                         </ComboBox>
                     </Border>
-                </StackPanel>
-                <StackPanel HorizontalAlignment="Center">
+                </Border>
+                <Border Background="Black" Padding="10" HorizontalAlignment="Center">
                     <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
                         <!-- The ComboBox item highlight DOESN'T show correctly in the Previewer, but it DOES in-app -->
                         <ComboBox PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
@@ -23,7 +23,7 @@
                             <ComboBoxItem Content="Item 3"/>
                         </ComboBox>
                     </Border>
-                </StackPanel>
+                </Border>
             </StackPanel>
         </Panel>
     </Design.PreviewWith>

--- a/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
@@ -3,28 +3,53 @@
         xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design">
     <Design.PreviewWith>
         <Panel Background="CornflowerBlue">
-            <StackPanel Margin="10" Spacing="10">
-                <Border Background="White" Padding="10" HorizontalAlignment="Center">
-                    <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
-                        <!-- (TODO) The ComboBox item highlight shows correctly in the Previewer, but not in-app. The foreground also looks wrong, but it shows correctly in-app  -->
-                        <ComboBox PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
-                            <ComboBoxItem Content="Item 1"/>
-                            <ComboBoxItem Content="Item 2"/>
-                            <ComboBoxItem Content="Item 3"/>
-                        </ComboBox>
+            <StackPanel Margin="10" Spacing="20" Orientation="Horizontal">
+                <StackPanel Spacing="10">
+                    <Border Background="White" Padding="10" HorizontalAlignment="Center">
+                        <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
+                            <!-- (TODO) The ComboBox item highlight shows correctly in the Previewer, but not in-app. The foreground also looks wrong, but it shows correctly in-app  -->
+                            <ComboBox PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
+                                <ComboBoxItem Content="Item 1"/>
+                                <ComboBoxItem Content="Item 2"/>
+                                <ComboBoxItem Content="Item 3"/>
+                            </ComboBox>
+                        </Border>
                     </Border>
-                </Border>
-                <Border Background="Black" Padding="10" HorizontalAlignment="Center">
-                    <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
-                        <!-- The ComboBox item highlight DOESN'T show correctly in the Previewer, but it DOES in-app -->
-                        <ComboBox PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
-                            <ComboBoxItem Content="Item 1"/>
-                            <ComboBoxItem Content="Item 2"/>
-                            <ComboBoxItem Content="Item 3"/>
-                        </ComboBox>
+                    <Border Background="Black" Padding="10" HorizontalAlignment="Center">
+                        <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
+                            <!-- The ComboBox item highlight DOESN'T show correctly in the Previewer, but it DOES in-app -->
+                            <ComboBox PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
+                                <ComboBoxItem Content="Item 1"/>
+                                <ComboBoxItem Content="Item 2"/>
+                                <ComboBoxItem Content="Item 3"/>
+                            </ComboBox>
+                        </Border>
                     </Border>
-                </Border>
+                </StackPanel>
+                
+                <StackPanel Spacing="10">
+                    <Border Background="White" Padding="10" HorizontalAlignment="Center">
+                        <Border design:NitroxAttached.Theme="LIGHT" Margin="0 0 0 110">
+                            <ComboBox Classes="text" PlaceholderText="Light" Width="200" HorizontalAlignment="Stretch">
+                                <ComboBoxItem Content="Item 1"/>
+                                <ComboBoxItem Content="Item 2"/>
+                                <ComboBoxItem Content="Item 3"/>
+                            </ComboBox>
+                        </Border>
+                    </Border>
+                    <Border Background="Black" Padding="10" HorizontalAlignment="Center">
+                        <Border design:NitroxAttached.Theme="DARK" Margin="0 0 0 110">
+                            <ComboBox Classes="text" PlaceholderText="Dark" Width="200" HorizontalAlignment="Stretch">
+                                <ComboBoxItem Content="Item 1"/>
+                                <ComboBoxItem Content="Item 2"/>
+                                <ComboBoxItem Content="Item 3"/>
+                            </ComboBox>
+                        </Border>
+                    </Border>
+                </StackPanel>
             </StackPanel>
+            
+            
         </Panel>
     </Design.PreviewWith>
     
@@ -67,7 +92,7 @@
                                        Margin="{TemplateBinding Padding}"
                                        Text="{TemplateBinding PlaceholderText}"
                                        IsVisible="{TemplateBinding SelectionBoxItem, Converter={x:Static ObjectConverters.IsNull}}" />
-                            <ContentControl Grid.Column="0" x:Name="ContentPresenter" Foreground="Blue"
+                            <ContentControl Grid.Column="0" x:Name="ContentPresenter"
                                             Content="{TemplateBinding SelectionBoxItem}"
                                             ContentTemplate="{TemplateBinding ItemTemplate}"
                                             Margin="{TemplateBinding Padding}"
@@ -166,6 +191,12 @@
         
     </Style>
     
-    
+    <!--Style Selector="ComboBox.text">
+        <Style Selector="ComboBox /template/ ContentControl">
+            <Setter Property="Content">
+                <ItemTe
+            </Setter>
+        </Style>
+    </Style-->
     
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ComboBoxStyle.axaml
@@ -35,7 +35,7 @@
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="BorderThickness" Value="0" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
-        <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="true"/> <!-- This one may be bad -->
+        <Setter Property="ScrollViewer.IsScrollInertiaEnabled" Value="true"/>
         <Setter Property="FontSize" Value="16" />
         <Setter Property="FontWeight" Value="Normal" />
         <Setter Property="CornerRadius" Value="8" />
@@ -158,6 +158,10 @@
         
         <Style Selector="^:pressed">
             <Setter Property="RenderTransform" Value="scale(0.98)" />
+        </Style>
+        
+        <Style Selector="^:disabled">
+            <Setter Property="Background" Value="{TemplateBinding Background}" />
         </Style>
         
     </Style>

--- a/Nitrox.Launcher/Styles/Theme/Index.axaml
+++ b/Nitrox.Launcher/Styles/Theme/Index.axaml
@@ -37,9 +37,18 @@
         <Setter Property="Background" Value="#ECECEC" />
         <Setter Property="Padding" Value="24 20" />
     </Style>
-
-    <!-- TODO: a good-looking focus overlay, compatible with all controls -->
+    
     <Style Selector=":is(Control)">
+        <Style Selector="^ /template/ ContentPresenter">
+            <Setter Property="Opacity" Value="1" />
+            <Setter Property="Transitions">
+                <Transitions>
+                    <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+                </Transitions>
+            </Setter>
+        </Style>
+        
+        <!-- TODO: a good-looking focus overlay, compatible with all controls -->
         <Setter Property="FocusAdorner">
             <Setter.Value>
                 <FocusAdornerTemplate>
@@ -47,6 +56,7 @@
                 </FocusAdornerTemplate>
             </Setter.Value>
         </Setter>
+        
         <Style Selector="^:disabled">
             <Setter Property="Opacity" Value=".85" />
         </Style>

--- a/Nitrox.Launcher/Styles/Theme/Index.axaml
+++ b/Nitrox.Launcher/Styles/Theme/Index.axaml
@@ -165,6 +165,7 @@
     <StyleInclude Source="/Styles/Theme/ToolTipStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/TextBlockStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/ButtonStyle.axaml" />
+    <StyleInclude Source="/Styles/Theme/ComboBoxStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/NavigationStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/RadioButtonGroupStyle.axaml" />
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/Index.axaml
+++ b/Nitrox.Launcher/Styles/Theme/Index.axaml
@@ -169,4 +169,5 @@
     <StyleInclude Source="/Styles/Theme/CheckBoxStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/NavigationStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/RadioButtonGroupStyle.axaml" />
+    <StyleInclude Source="/Styles/Theme/ScrollViewerStyle.axaml" />
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/Index.axaml
+++ b/Nitrox.Launcher/Styles/Theme/Index.axaml
@@ -166,6 +166,7 @@
     <StyleInclude Source="/Styles/Theme/TextBlockStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/ButtonStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/ComboBoxStyle.axaml" />
+    <StyleInclude Source="/Styles/Theme/CheckBoxStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/NavigationStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/RadioButtonGroupStyle.axaml" />
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/Index.axaml
+++ b/Nitrox.Launcher/Styles/Theme/Index.axaml
@@ -47,6 +47,9 @@
                 </FocusAdornerTemplate>
             </Setter.Value>
         </Setter>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value=".85" />
+        </Style>
     </Style>
 
     <Style Selector=".form > :is(Layoutable)">
@@ -162,12 +165,13 @@
 
     <StyleInclude Source="/Styles/Theme/ValidationErrorsStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/TextBoxStyle.axaml" />
-    <StyleInclude Source="/Styles/Theme/ToolTipStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/TextBlockStyle.axaml" />
+    <StyleInclude Source="/Styles/Theme/ToolTipStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/ButtonStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/ComboBoxStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/CheckBoxStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/NavigationStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/RadioButtonGroupStyle.axaml" />
+    <StyleInclude Source="/Styles/Theme/RadioButtonStyle.axaml" />
     <StyleInclude Source="/Styles/Theme/ScrollViewerStyle.axaml" />
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/RadioButtonGroupStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/RadioButtonGroupStyle.axaml
@@ -71,7 +71,6 @@
     </Style>
     <Style Selector="ItemsControl.radioGroup:disabled">
         <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
-        <!--Setter Property="Opacity" Value=".5"/-->
         <Style Selector="^ Button#ItemContainer /template/ ContentPresenter">
             <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
             <Setter Property="BorderBrush" Value="{Binding BorderBrush, RelativeSource={RelativeSource AncestorType=Button}}" />

--- a/Nitrox.Launcher/Styles/Theme/RadioButtonGroupStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/RadioButtonGroupStyle.axaml
@@ -69,6 +69,14 @@
     <Style Selector="ItemsControl.radioGroup Button#ItemContainer:pointerover /template/ ContentPresenter">
         <Setter Property="BorderBrush" Value="{Binding BorderBrush, RelativeSource={RelativeSource AncestorType=Button}}" />
     </Style>
+    <Style Selector="ItemsControl.radioGroup:disabled">
+        <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
+        <!--Setter Property="Opacity" Value=".5"/-->
+        <Style Selector="^ Button#ItemContainer /template/ ContentPresenter">
+            <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=Button}}" />
+            <Setter Property="BorderBrush" Value="{Binding BorderBrush, RelativeSource={RelativeSource AncestorType=Button}}" />
+        </Style>
+    </Style>
 
     <!-- Events -->
     <Style Selector="ItemsControl.radioGroup Button#ItemContainer:pointerover">

--- a/Nitrox.Launcher/Styles/Theme/RadioButtonStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/RadioButtonStyle.axaml
@@ -1,0 +1,222 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design">
+    <Design.PreviewWith>
+        <Panel Background="CornflowerBlue">
+            <StackPanel Margin="10" Spacing="15">
+                <StackPanel Orientation="Horizontal" Spacing="5" HorizontalAlignment="Center">
+                    <Border Background="White" design:NitroxAttached.Theme="LIGHT" Padding="5">
+                        <StackPanel Spacing="10">
+                            <RadioButton Content="Option 1" IsChecked="True" />
+                            <RadioButton Content="Option 2" />
+                            <RadioButton Content="Option 3" />
+                            <RadioButton Content="Option 4" />
+                        </StackPanel>
+                    </Border>
+                    <Border Background="Black" design:NitroxAttached.Theme="DARK" Padding="5">
+                        <StackPanel Spacing="10">
+                            <RadioButton Content="Option 1" />
+                            <RadioButton Content="Option 2" IsChecked="True" />
+                            <RadioButton Content="Option 3" />
+                            <RadioButton Content="Option 4" />
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+            </StackPanel>
+        </Panel>
+    </Design.PreviewWith>
+
+    <Style Selector="RadioButton">
+        <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
+            <Setter Property="Foreground" Value="White" />
+        </Style>
+        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
+            <Setter Property="Foreground" Value="#3b3b3b" />
+        </Style>
+        
+        <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+        <Setter Property="CornerRadius" Value="{DynamicResource ControlCornerRadius}" />
+        <Setter Property="Padding" Value="8,0,0,0" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="FontSize" Value="{DynamicResource ControlContentThemeFontSize}" />
+        <Setter Property="Transitions">
+            <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
+                <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+            </Transitions>
+        </Setter>
+        <Setter Property="Template">
+            <ControlTemplate TargetType="RadioButton">
+                <Border Name="RootBorder"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="{TemplateBinding CornerRadius}">
+                    <Grid ColumnDefinitions="20,*">
+                        <Grid Height="32" VerticalAlignment="Top">
+                            
+                            <Ellipse Name="OuterEllipse"
+                                     Width="20"
+                                     Height="20"
+                                     Fill="White"
+                                     Stroke="{TemplateBinding Foreground}"
+                                     StrokeThickness="{DynamicResource RadioButtonBorderThemeThickness}"
+                                     UseLayoutRounding="False" />
+                            
+                            <Ellipse Name="CheckOuterEllipse"
+                                     Width="20"
+                                     Height="20"
+                                     Fill="{DynamicResource RadioButtonOuterEllipseCheckedFill}"
+                                     Opacity="0"
+                                     Stroke="{DynamicResource RadioButtonOuterEllipseCheckedStroke}"
+                                     StrokeThickness="{DynamicResource RadioButtonBorderThemeThickness}"
+                                     UseLayoutRounding="False" />
+                            
+                            <Ellipse Name="CheckGlyph"
+                                     Width="8"
+                                     Height="8"
+                                     Fill="{DynamicResource RadioButtonCheckGlyphFill}"
+                                     Opacity="0"
+                                     Stroke="{DynamicResource RadioButtonCheckGlyphStroke}"
+                                     UseLayoutRounding="False" />
+                            
+                        </Grid>
+                        
+                        <ContentPresenter Name="PART_ContentPresenter"
+                                          Grid.Column="1"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          RecognizesAccessKey="True" />
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+        
+        
+        <!--  PointerOver State  -->
+        <Style Selector="^:pointerover">
+            <Setter Property="Opacity" Value=".75" />
+            
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{TemplateBinding Foreground}" />
+            </Style>
+            
+            <Style Selector="^ /template/ Border#RootBorder">
+                <Setter Property="Background" Value="{DynamicResource RadioButtonBackground}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#OuterEllipse">
+                <Setter Property="Stroke" Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RadioButton}}" />
+                <Setter Property="Fill" Value="White" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckOuterEllipse">
+                <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
+                <Setter Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedFill}" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckGlyph">
+                <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckGlyphStroke}" />
+                <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckGlyphFill}" />
+            </Style>
+        </Style>
+        
+        
+        <!--  Pressed State  -->
+        <Style Selector="^:pressed">
+            <Setter Property="RenderTransform" Value="scale(0.98)" />
+            
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{TemplateBinding Foreground}" />
+            </Style>
+            
+            <Style Selector="^ /template/ Border#RootBorder">
+                <Setter Property="Background" Value="{DynamicResource RadioButtonBackgroundPressed}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrushPressed}" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#OuterEllipse">
+                <Setter Property="Stroke" Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RadioButton}}" />
+                <Setter Property="Fill" Value="White" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckOuterEllipse">
+                <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStrokePressed}" />
+                <Setter Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedFillPressed}" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckGlyph">
+                <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckGlyphStrokePressed}" />
+                <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckGlyphFillPressed}" />
+            </Style>
+        </Style>
+        
+        
+        <!--  Disabled State  -->
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Foreground" Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RadioButton}}" />
+            </Style>
+            
+            <Style Selector="^ /template/ Border#RootBorder">
+                <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=RadioButton}}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource RadioButtonBorderBrush}" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#OuterEllipse">
+                <Setter Property="Stroke" Value="{Binding Foreground, RelativeSource={RelativeSource AncestorType=RadioButton}}" />
+                <Setter Property="Fill" Value="White" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckOuterEllipse">
+                <Setter Property="Stroke" Value="{DynamicResource RadioButtonOuterEllipseCheckedStroke}" />
+                <Setter Property="Fill" Value="{DynamicResource RadioButtonOuterEllipseCheckedFill}" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckGlyph">
+                <Setter Property="Stroke" Value="{DynamicResource RadioButtonCheckGlyphStroke}" />
+                <Setter Property="Fill" Value="{DynamicResource RadioButtonCheckGlyphFill}" />
+            </Style>
+            
+            <Style Selector="^:unchecked">
+                <Style Selector="^ /template/ Ellipse#CheckGlyph">
+                    <Setter Property="Opacity" Value="0" />
+                </Style>
+            
+                <Style Selector="^ /template/ Ellipse#OuterEllipse">
+                    <Setter Property="Opacity" Value="1" />
+                </Style>
+
+                <Style Selector="^ /template/ Ellipse#CheckOuterEllipse">
+                    <Setter Property="Opacity" Value="0" />
+                </Style>
+            </Style>
+        </Style>
+        
+        
+        <!--  Checked State  -->
+        <Style Selector="^:checked">
+            <Style Selector="^ /template/ Ellipse#CheckGlyph">
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+            
+            <Style Selector="^ /template/ Ellipse#OuterEllipse">
+                <Setter Property="Opacity" Value="0" />
+            </Style>
+
+            <Style Selector="^ /template/ Ellipse#CheckOuterEllipse">
+                <Setter Property="Opacity" Value="1" />
+            </Style>
+        </Style>
+
+    </Style>
+</Styles>

--- a/Nitrox.Launcher/Styles/Theme/ScrollViewerStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/ScrollViewerStyle.axaml
@@ -1,0 +1,231 @@
+﻿<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design">
+    <Design.PreviewWith>
+        <Panel Background="CornflowerBlue">
+            <StackPanel Margin="10" Spacing="20">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <Border Background="White" design:NitroxAttached.Theme="LIGHT" Padding="10 10 0 10">
+                        <ScrollViewer Width="200" Height="200">
+                            <StackPanel Spacing="20">
+                                <TextBlock Foreground="Black">Item 1</TextBlock>
+                                <TextBlock Foreground="Black">Item 2</TextBlock>
+                                <TextBlock Foreground="Black">Item 3</TextBlock>
+                                <TextBlock Foreground="Black">Item 4</TextBlock>
+                                <TextBlock Foreground="Black">Item 5</TextBlock>
+                                <TextBlock Foreground="Black">Item 6</TextBlock>
+                                <TextBlock Foreground="Black">Item 7</TextBlock>
+                                <TextBlock Foreground="Black">Item 8</TextBlock>
+                                <TextBlock Foreground="Black">Item 9</TextBlock>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                    <Border Background="Black" design:NitroxAttached.Theme="DARK" Padding="10 10 0 10">
+                        <ScrollViewer Width="200" Height="200">
+                            <StackPanel Spacing="20">
+                                <TextBlock>Item 1</TextBlock>
+                                <TextBlock>Item 2</TextBlock>
+                                <TextBlock>Item 3</TextBlock>
+                                <TextBlock>Item 4</TextBlock>
+                                <TextBlock>Item 5</TextBlock>
+                                <TextBlock>Item 6</TextBlock>
+                                <TextBlock>Item 7</TextBlock>
+                                <TextBlock>Item 8</TextBlock>
+                                <TextBlock>Item 9</TextBlock>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                </StackPanel>
+                <StackPanel Spacing="10">
+                    <Border Background="White" design:NitroxAttached.Theme="LIGHT" Padding="10 10 10 0">
+                        <ScrollViewer Width="410" HorizontalAlignment="Left" HorizontalContentAlignment="Left" HorizontalScrollBarVisibility="Visible">
+                            <StackPanel Orientation="Horizontal" Spacing="20">
+                                <TextBlock Foreground="Black">Item 1</TextBlock>
+                                <TextBlock Foreground="Black">Item 2</TextBlock>
+                                <TextBlock Foreground="Black">Item 3</TextBlock>
+                                <TextBlock Foreground="Black">Item 4</TextBlock>
+                                <TextBlock Foreground="Black">Item 5</TextBlock>
+                                <TextBlock Foreground="Black">Item 6</TextBlock>
+                                <TextBlock Foreground="Black">Item 7</TextBlock>
+                                <TextBlock Foreground="Black">Item 8</TextBlock>
+                                <TextBlock Foreground="Black">Item 9</TextBlock>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                    <Border Background="Black" design:NitroxAttached.Theme="DARK" Padding="10 10 10 0">
+                        <ScrollViewer Width="410" HorizontalAlignment="Left" HorizontalContentAlignment="Left" HorizontalScrollBarVisibility="Visible">
+                            <StackPanel Orientation="Horizontal" Spacing="20">
+                                <TextBlock>Item 1</TextBlock>
+                                <TextBlock>Item 2</TextBlock>
+                                <TextBlock>Item 3</TextBlock>
+                                <TextBlock>Item 4</TextBlock>
+                                <TextBlock>Item 5</TextBlock>
+                                <TextBlock>Item 6</TextBlock>
+                                <TextBlock>Item 7</TextBlock>
+                                <TextBlock>Item 8</TextBlock>
+                                <TextBlock>Item 9</TextBlock>
+                            </StackPanel>
+                        </ScrollViewer>
+                    </Border>
+                </StackPanel>
+                
+            </StackPanel>
+        </Panel>
+    </Design.PreviewWith>
+    
+    <Style Selector="ScrollViewer">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="HorizontalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Grid ColumnDefinitions="*,Auto" RowDefinitions="*,Auto">
+                    <ScrollContentPresenter Name="PART_ContentPresenter"
+                                            Background="{TemplateBinding Background}"
+                                            HorizontalSnapPointsType="{TemplateBinding HorizontalSnapPointsType}"
+                                            VerticalSnapPointsType="{TemplateBinding VerticalSnapPointsType}"
+                                            HorizontalSnapPointsAlignment="{TemplateBinding HorizontalSnapPointsAlignment}"
+                                            VerticalSnapPointsAlignment="{TemplateBinding VerticalSnapPointsAlignment}"
+                                            Padding="{TemplateBinding Padding}"
+                                            ScrollViewer.IsScrollInertiaEnabled="{TemplateBinding IsScrollInertiaEnabled}">
+                        <ScrollContentPresenter.GestureRecognizers>
+                             <ScrollGestureRecognizer CanHorizontallyScroll="{Binding CanHorizontallyScroll, ElementName=PART_ContentPresenter}"
+                                                      CanVerticallyScroll="{Binding CanVerticallyScroll, ElementName=PART_ContentPresenter}"
+                                                      IsScrollInertiaEnabled="{Binding (ScrollViewer.IsScrollInertiaEnabled), ElementName=PART_ContentPresenter}"/>
+                        </ScrollContentPresenter.GestureRecognizers>
+                    </ScrollContentPresenter>
+                    <ScrollBar Name="PART_HorizontalScrollBar"
+                               Orientation="Horizontal" Margin="0 5 0 0"
+                               Grid.Row="1" />
+                    <ScrollBar Name="PART_VerticalScrollBar"
+                               Orientation="Vertical" Margin="5 0 0 0"
+                               Grid.Column="1" />
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    
+    <Style Selector="ScrollBar">
+        <Setter Property="MinWidth" Value="{DynamicResource ScrollBarSize}" />
+        <Setter Property="MinHeight" Value="{DynamicResource ScrollBarSize}" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="AllowAutoHide" Value="False"/>
+    
+        <Style Selector="^:vertical">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Grid x:Name="Root">
+                        <Border x:Name="VerticalRoot"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}">
+                            <Track Minimum="{TemplateBinding Minimum}"
+                                   Maximum="{TemplateBinding Maximum}"
+                                   Value="{TemplateBinding Value, Mode=TwoWay}"
+                                   ViewportSize="{TemplateBinding ViewportSize}"
+                                   Orientation="{TemplateBinding Orientation}"
+                                   IsDirectionReversed="True">
+                                <Track.DecreaseButton>
+                                    <RepeatButton Name="PART_PageUpButton"
+                                                  Classes="largeIncrease"
+                                                  Focusable="False" />
+                                </Track.DecreaseButton>
+                                <Track.IncreaseButton>
+                                    <RepeatButton Name="PART_PageDownButton"
+                                                  Classes="largeIncrease"
+                                                  Focusable="False" />
+                                </Track.IncreaseButton>
+                                <Thumb Width="8"
+                                       MinHeight="8"
+                                       RenderTransform="{DynamicResource VerticalSmallScrollThumbScaleTransform}"
+                                       RenderTransformOrigin="100%,50%" />
+                            </Track>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+    
+        <Style Selector="^:horizontal">
+            <Setter Property="Template">
+                <ControlTemplate>
+                    <Grid x:Name="Root">
+                        <Border x:Name="HorizontalRoot"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}">
+                            <Track Minimum="{TemplateBinding Minimum}"
+                                   Maximum="{TemplateBinding Maximum}"
+                                   Value="{TemplateBinding Value, Mode=TwoWay}"
+                                   ViewportSize="{TemplateBinding ViewportSize}"
+                                   Orientation="{TemplateBinding Orientation}">
+                                <Track.DecreaseButton>
+                                    <RepeatButton Name="PART_PageUpButton"
+                                                  Classes="largeIncrease"
+                                                  Focusable="False" />
+                                </Track.DecreaseButton>
+                                <Track.IncreaseButton>
+                                    <RepeatButton Name="PART_PageDownButton"
+                                                  Classes="largeIncrease"
+                                                  Focusable="False" />
+                                </Track.IncreaseButton>
+                                <Thumb Height="8"
+                                       MinWidth="8"
+                                       RenderTransform="{DynamicResource HorizontalSmallScrollThumbScaleTransform}"
+                                       RenderTransformOrigin="50%,100%" />
+                            </Track>
+                        </Border>
+                    </Grid>
+                </ControlTemplate>
+            </Setter>
+        </Style>
+    </Style>
+    
+    <Style Selector="Thumb">
+        <Style Selector="^[(design|NitroxAttached.Theme)=LIGHT]">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Border Background="#cccccc"
+                                CornerRadius="4"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border">
+                <Setter Property="Background" Value="#8f8f8f" />
+            </Style>
+            <Style Selector="^:pressed  /template/ Border">
+                <Setter Property="Background" Value="#3f3f3f" />
+            </Style>
+        </Style>
+        
+        <Style Selector="^[(design|NitroxAttached.Theme)=DARK]">
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate>
+                        <Border Background="#262626"
+                                CornerRadius="4"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+            <Style Selector="^:pointerover /template/ Border">
+                <Setter Property="Background" Value="#3f3f3f" />
+            </Style>
+            <Style Selector="^:pressed  /template/ Border">
+                <Setter Property="Background" Value="#8f8f8f" />
+            </Style>
+        </Style>
+    </Style>
+
+    <Style Selector="RepeatButton">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="VerticalAlignment" Value="Stretch" />
+        <Setter Property="HorizontalAlignment" Value="Stretch" />
+        <Setter Property="Opacity" Value="0" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border Background="{TemplateBinding Background}" />
+            </ControlTemplate>
+        </Setter>
+    </Style>
+    
+</Styles>

--- a/Nitrox.Launcher/Styles/Theme/TextBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/TextBoxStyle.axaml
@@ -19,7 +19,50 @@
             </Style>
             <Setter Property="Foreground" Value="{TemplateBinding Foreground}" />
         </Style>
+        
+        <Style Selector="^.revealPasswordButton[AcceptsReturn=False][IsReadOnly=False]:not(TextBox:empty)">
+            <Setter Property="InnerRightContent">
+                <Template>
+                    <ToggleButton IsChecked="{Binding $parent[TextBox].RevealPassword, Mode=TwoWay}" Focusable="False" Width="35">
+                        <Grid>
+                            <!-- TODO: Replace these with image icons -->
+                            <PathIcon Data="m10.051 7.0032c2.215 0 4.0105 1.7901 4.0105 3.9984s-1.7956 3.9984-4.0105 3.9984c-2.215 0-4.0105-1.7901-4.0105-3.9984s1.7956-3.9984 4.0105-3.9984zm0 1.4994c-1.3844 0-2.5066 1.1188-2.5066 2.499s1.1222 2.499 2.5066 2.499 2.5066-1.1188 2.5066-2.499-1.1222-2.499-2.5066-2.499zm0-5.0026c4.6257 0 8.6188 3.1487 9.7267 7.5613 0.10085 0.40165-0.14399 0.80877-0.54686 0.90931-0.40288 0.10054-0.81122-0.14355-0.91208-0.54521-0.94136-3.7492-4.3361-6.4261-8.2678-6.4261-3.9334 0-7.3292 2.6792-8.2689 6.4306-0.10063 0.40171-0.50884 0.64603-0.91177 0.54571s-0.648-0.5073-0.54737-0.90901c1.106-4.4152 5.1003-7.5667 9.728-7.5667z"
+                                      Height="8" Width="12"
+                                      IsVisible="{Binding !$parent[ToggleButton].IsChecked}"/>
+                            <PathIcon Data="m0.21967 0.21965c-0.26627 0.26627-0.29047 0.68293-0.07262 0.97654l0.07262 0.08412 4.0346 4.0346c-1.922 1.3495-3.3585 3.365-3.9554 5.7495-0.10058 0.4018 0.14362 0.8091 0.54543 0.9097 0.40182 0.1005 0.80909-0.1436 0.90968-0.5455 0.52947-2.1151 1.8371-3.8891 3.5802-5.0341l1.8096 1.8098c-0.70751 0.7215-1.1438 1.71-1.1438 2.8003 0 2.2092 1.7909 4 4 4 1.0904 0 2.0788-0.4363 2.8004-1.1438l5.9193 5.9195c0.2929 0.2929 0.7677 0.2929 1.0606 0 0.2663-0.2662 0.2905-0.6829 0.0726-0.9765l-0.0726-0.0841-6.1135-6.1142 0.0012-0.0015-1.2001-1.1979-2.8699-2.8693 2e-3 -8e-4 -2.8812-2.8782 0.0012-0.0018-1.1333-1.1305-4.3064-4.3058c-0.29289-0.29289-0.76777-0.29289-1.0607 0zm7.9844 9.0458 3.5351 3.5351c-0.45 0.4358-1.0633 0.704-1.7392 0.704-1.3807 0-2.5-1.1193-2.5-2.5 0-0.6759 0.26824-1.2892 0.7041-1.7391zm1.7959-5.7655c-1.0003 0-1.9709 0.14807-2.8889 0.425l1.237 1.2362c0.5358-0.10587 1.0883-0.16119 1.6519-0.16119 3.9231 0 7.3099 2.6803 8.2471 6.4332 0.1004 0.4018 0.5075 0.6462 0.9094 0.5459 0.4019-0.1004 0.6463-0.5075 0.5459-0.9094-1.103-4.417-5.0869-7.5697-9.7024-7.5697zm0.1947 3.5093 3.8013 3.8007c-0.1018-2.0569-1.7488-3.7024-3.8013-3.8007z"
+                                      Height="12" Width="12"
+                                      IsVisible="{Binding $parent[ToggleButton].IsChecked}"/>
+                        </Grid>
+                        
+                        <ToggleButton.Styles>
+                            <Style Selector="ToggleButton">
+                                <Setter Property="Transitions">
+                                    <Transitions>
+                                        <DoubleTransition Property="Opacity" Duration="0:0:0.15" />
+                                        <TransformOperationsTransition Property="RenderTransform" Duration="0:0:.075" />
+                                    </Transitions>
+                                </Setter>
+                                <Setter Property="Background" Value="Transparent"/>
+                                
+                                <Style Selector="^:pointerover /template/ ContentPresenter">
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="Opacity" Value=".5"/>
+                                    <Setter Property="Cursor" Value="Hand"/>
+                                </Style>
+                                <Style Selector="^:checked /template/ ContentPresenter">
+                                    <Setter Property="Background" Value="Transparent"/>
+                                </Style>
+                                <Style Selector="^:pressed /template/ ContentPresenter">
+                                    <Setter Property="Background" Value="Transparent"/>
+                                    <Setter Property="RenderTransform" Value="scale(0.95)"/>
+                                </Style>
+                                
+                            </Style>
+                        </ToggleButton.Styles>
+                    </ToggleButton>
+                </Template>
+            </Setter>
+        </Style>
+        
     </Style>
-
-    
 </Styles>

--- a/Nitrox.Launcher/Styles/Theme/TextBoxStyle.axaml
+++ b/Nitrox.Launcher/Styles/Theme/TextBoxStyle.axaml
@@ -6,11 +6,20 @@
         <Setter Property="Padding" Value="14" />
         <Setter Property="Background" Value="#ECECEC" />
         <Setter Property="BorderThickness" Value="0" />
+        
+        <Style Selector="^ /template/ Border">
+            <Setter Property="Background" Value="{TemplateBinding Background}" />
+            <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius}" />
+            <Setter Property="BorderThickness" Value="{TemplateBinding BorderThickness}" />
+        </Style>
+        
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Border">
+                <Setter Property="Background" Value="{TemplateBinding Background}" />
+            </Style>
+            <Setter Property="Foreground" Value="{TemplateBinding Foreground}" />
+        </Style>
     </Style>
 
-    <Style Selector="TextBox /template/ Border">
-        <Setter Property="Background" Value="{Binding Background, RelativeSource={RelativeSource AncestorType=TextBox}}" />
-        <Setter Property="CornerRadius" Value="{Binding CornerRadius, RelativeSource={RelativeSource AncestorType=TextBox}}" />
-        <Setter Property="BorderThickness" Value="{Binding BorderThickness, RelativeSource={RelativeSource AncestorType=TextBox}}" />
-    </Style>
+    
 </Styles>

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
-using Avalonia.Controls.Notifications;
 using Nitrox.Launcher.Models;
 using Nitrox.Launcher.ViewModels.Abstract;
 using Nitrox.Launcher.Views;
@@ -211,19 +210,13 @@ public class ManageServerViewModel : RoutableViewModelBase
     {
         this.BindValidation();
         
-        IObservable<bool> canExecuteManageServerCommands = this.WhenAnyValue(x => x.IsAnySettingChanged);
+        IObservable<bool> canExecuteSaveUndoCommands = this.WhenAnyValue(x => x.IsAnySettingChanged);
+        IObservable<bool> canExecuteManageServerCommands = this.WhenAnyValue(x => x.IsAnySettingChanged, (value) => !value);
         
         BackCommand = ReactiveCommand.Create(() =>
         {
-            if (CheckIfAnySettingChanged())
-            {
-                Console.WriteLine("Save your changes before continuing"); // TODO: Launcher Notification
-            }
-            else
-            {
-                Router.NavigateBack.Execute();
-            }
-        });
+            Router.NavigateBack.Execute();
+        }, canExecuteManageServerCommands);
         
         SaveCommand = ReactiveCommand.Create(() =>
         {
@@ -245,7 +238,7 @@ public class ManageServerViewModel : RoutableViewModelBase
             Server.AllowCommands = ServerAllowCommands;
             
             CheckIfAnySettingChanged();
-        }, canExecuteManageServerCommands);
+        }, canExecuteSaveUndoCommands);
         
         UndoCommand = ReactiveCommand.Create(() =>
         {
@@ -261,19 +254,12 @@ public class ManageServerViewModel : RoutableViewModelBase
             ServerAutoPortForward = Server.AutoPortForward;
             ServerAllowLanDiscovery = Server.AllowLanDiscovery;
             ServerAllowCommands = Server.AllowCommands;
-        }, canExecuteManageServerCommands);
+        }, canExecuteSaveUndoCommands);
         
         StartServerCommand = ReactiveCommand.Create(() =>
         {
-            if (CheckIfAnySettingChanged())
-            {
-                Console.WriteLine("Save your changes before starting the server"); // TODO: Launcher Notification
-            }
-            else
-            {
-                Server.StartCommand.Execute(null);
-            }
-        });
+            Server.StartCommand.Execute(null);
+        }, canExecuteManageServerCommands);
     }
     public void LoadFrom(ServerEntry serverEntry)
     {

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -9,7 +9,6 @@ namespace Nitrox.Launcher.ViewModels;
 public class ManageServerViewModel : RoutableViewModelBase
 {
     private string serverName;
-
     /// <summary>
     ///     When set, navigates to the <see cref="ManageServerView" />.
     /// </summary>
@@ -18,7 +17,23 @@ public class ManageServerViewModel : RoutableViewModelBase
         get => serverName;
         set => this.RaiseAndSetIfChanged(ref serverName, value);
     }
+    
+    private string serverPassword;
+    /// <summary>
+    ///     When set, navigates to the <see cref="ManageServerView" />.
+    /// </summary>
+    public string ServerPassword
+    {
+        get => serverPassword;
+        set => this.RaiseAndSetIfChanged(ref serverPassword, value);
+    }
 
+    private GameMode serverGameMode;
+    public GameMode ServerGameMode
+    {
+        get => serverGameMode;
+        set => this.RaiseAndSetIfChanged(ref serverGameMode, value);
+    }
     public ReactiveCommand<Unit, IRoutableViewModel> BackCommand { get; init; }
 
     public ManageServerViewModel(IScreen hostScreen) : base(hostScreen)
@@ -30,5 +45,7 @@ public class ManageServerViewModel : RoutableViewModelBase
     public void LoadFrom(ServerEntry server)
     {
         ServerName = server.Name;
+        ServerPassword = ""; // Need to add password config
+        ServerGameMode = server.GameMode;
     }
 }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 using System.Reactive;
 using Nitrox.Launcher.Models;
@@ -17,21 +18,168 @@ public class ManageServerViewModel : RoutableViewModelBase
     public ServerEntry Server
     {
         get => server;
-        set => this.RaiseAndSetIfChanged(ref server, value);
+        set
+        {
+            if (server != null)
+            {
+                server.PropertyChanged -= Server_PropertyChanged;
+            }
+            this.RaiseAndSetIfChanged(ref server, value);
+            if (server != null)
+            {
+                server.PropertyChanged += Server_PropertyChanged;
+            }
+        }
+    }
+    
+    private bool serverIsOnline;
+    public bool ServerIsOnline
+    {
+        get => Server.IsOnline;
+        set => this.RaiseAndSetIfChanged(ref serverIsOnline, value);
+    }
+
+    private string serverName;
+    public string ServerName
+    {
+        get => serverName;
+        set => this.RaiseAndSetIfChanged(ref serverName, value);
+    }
+
+    private string serverPassword;
+    public string ServerPassword
+    {
+        get => serverPassword;
+        set => this.RaiseAndSetIfChanged(ref serverPassword, value);
+    }
+
+    private GameMode serverGameMode;
+    public GameMode ServerGameMode
+    {
+        get => serverGameMode;
+        set => this.RaiseAndSetIfChanged(ref serverGameMode, value);
+    }
+
+    private string serverSeed;
+    public string ServerSeed
+    {
+        get => serverSeed;
+        set => this.RaiseAndSetIfChanged(ref serverSeed, value);
+    }
+
+    private PlayerPermissions serverDefaultPlayerPerm;
+    public PlayerPermissions ServerDefaultPlayerPerm
+    {
+        get => serverDefaultPlayerPerm;
+        set => this.RaiseAndSetIfChanged(ref serverDefaultPlayerPerm, value);
+    }
+
+    private int serverAutoSaveInterval;
+    public int ServerAutoSaveInterval
+    {
+        get => serverAutoSaveInterval;
+        set => this.RaiseAndSetIfChanged(ref serverAutoSaveInterval, value);
+    }
+
+    private int serverMaxPlayers;
+    public int ServerMaxPlayers
+    {
+        get => serverMaxPlayers;
+        set => this.RaiseAndSetIfChanged(ref serverMaxPlayers, value);
+    }
+
+    private int serverPlayers;
+    public int ServerPlayers
+    {
+        get => serverPlayers;
+        set => this.RaiseAndSetIfChanged(ref serverPlayers, value);
+    }
+
+    private int serverPort;
+    public int ServerPort
+    {
+        get => serverPort;
+        set => this.RaiseAndSetIfChanged(ref serverPort, value);
+    }
+
+    private bool serverAutoPortForward;
+    public bool ServerAutoPortForward
+    {
+        get => serverAutoPortForward;
+        set => this.RaiseAndSetIfChanged(ref serverAutoPortForward, value);
+    }
+
+    private bool serverAllowLanDiscovery;
+    public bool ServerAllowLanDiscovery
+    {
+        get => serverAllowLanDiscovery;
+        set => this.RaiseAndSetIfChanged(ref serverAllowLanDiscovery, value);
+    }
+    
+    private bool serverAllowCommands;
+    public bool ServerAllowCommands
+    {
+        get => serverAllowCommands;
+        set => this.RaiseAndSetIfChanged(ref serverAllowCommands, value);
     }
     
     private string worldFolderDirectory;
     
-    public ReactiveCommand<Unit, IRoutableViewModel> BackCommand { get; init; }
+    public ReactiveCommand<Unit, Unit> BackCommand { get; init; }
 
     public ManageServerViewModel(IScreen hostScreen) : base(hostScreen)
     {
         this.BindValidation();
-        BackCommand = Router.NavigateBack;
+        BackCommand = ReactiveCommand.Create(() =>
+        {
+            Save();
+            Router.NavigateBack.Execute();
+        });
     }
     public void LoadFrom(ServerEntry serverEntry)
     {
         Server = serverEntry;
         worldFolderDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox", "saves", Server.Name);
+        
+        ServerIsOnline = Server.IsOnline;
+        
+        ServerName = Server.Name;
+        ServerPassword = Server.Password;
+        ServerGameMode = Server.GameMode;
+        ServerSeed = Server.Seed;
+        ServerDefaultPlayerPerm = Server.DefaultPlayerPerm;
+        ServerAutoSaveInterval = Server.AutoSaveInterval;
+        ServerMaxPlayers = Server.MaxPlayers;
+        ServerPlayers = Server.Players;
+        ServerPort = Server.Port;
+        ServerAutoPortForward = Server.AutoPortForward;
+        ServerAllowLanDiscovery = Server.AllowLanDiscovery;
+        ServerAllowCommands = Server.AllowCommands;
+    }
+
+    private void Save()
+    {
+        // TODO: Check for invalid value inputs and throw an error if one is found
+        
+        Server.Name = ServerName;
+        Server.Password = ServerPassword;
+        Server.GameMode = ServerGameMode;
+        Server.Seed = ServerSeed;
+        Server.DefaultPlayerPerm = ServerDefaultPlayerPerm;
+        Server.AutoSaveInterval = ServerAutoSaveInterval;
+        Server.MaxPlayers = ServerMaxPlayers;
+        Server.Players = ServerPlayers;
+        Server.Port = ServerPort;
+        Server.AutoPortForward = ServerAutoPortForward;
+        Server.AllowLanDiscovery = ServerAllowLanDiscovery;
+        Server.AllowCommands = ServerAllowCommands;
+    }
+    
+    private void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ServerEntry.IsOnline))
+        {
+            this.RaisePropertyChanged(nameof(ServerIsOnline));
+        }
     }
 }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Reactive;
+﻿using System;
+using System.IO;
+using System.Reactive;
 using Nitrox.Launcher.Models;
 using Nitrox.Launcher.ViewModels.Abstract;
 using Nitrox.Launcher.Views;
@@ -9,110 +11,15 @@ namespace Nitrox.Launcher.ViewModels;
 public class ManageServerViewModel : RoutableViewModelBase
 {
     private ServerEntry server;
+    /// <summary>
+    ///     When set, navigates to the <see cref="ManageServerView" />.
+    /// </summary>
     public ServerEntry Server
     {
         get => server;
         set => this.RaiseAndSetIfChanged(ref server, value);
     }
     
-    
-    private bool serverIsOnline;
-    public bool ServerIsOnline
-    {
-        get => serverIsOnline;
-        set => this.RaiseAndSetIfChanged(ref serverIsOnline, value);
-    }
-    
-    private string serverName;
-    /// <summary>
-    ///     When set, navigates to the <see cref="ManageServerView" />.
-    /// </summary>
-    public string ServerName
-    {
-        get => serverName;
-        set => this.RaiseAndSetIfChanged(ref serverName, value);
-    }
-    
-    private string serverPassword;
-    /// <summary>
-    ///     When set, navigates to the <see cref="ManageServerView" />.
-    /// </summary>
-    public string ServerPassword
-    {
-        get => serverPassword;
-        set => this.RaiseAndSetIfChanged(ref serverPassword, value);
-    }
-
-    private GameMode serverGameMode;
-    public GameMode ServerGameMode
-    {
-        get => serverGameMode;
-        set => this.RaiseAndSetIfChanged(ref serverGameMode, value);
-    }
-    
-    private string serverSeed;
-    public string ServerSeed
-    {
-        get => serverSeed;
-        set => this.RaiseAndSetIfChanged(ref serverSeed, value);
-    }
-    
-    private PlayerPermissions serverDefaultPerms;
-    public PlayerPermissions ServerDefaultPerms
-    {
-        get => serverDefaultPerms;
-        set => this.RaiseAndSetIfChanged(ref serverDefaultPerms, value);
-    }
-    
-    private int serverAutoSaveInterval;
-    public int ServerAutoSaveInterval
-    {
-        get => serverAutoSaveInterval;
-        set => this.RaiseAndSetIfChanged(ref serverAutoSaveInterval, value);
-    }
-    
-    private int serverPlayerLimit;
-    public int ServerPlayerLimit
-    {
-        get => serverPlayerLimit;
-        set => this.RaiseAndSetIfChanged(ref serverPlayerLimit, value);
-    }
-    
-    private int serverPlayerCount;
-    public int ServerPlayerCount
-    {
-        get => serverPlayerCount;
-        set => this.RaiseAndSetIfChanged(ref serverPlayerCount, value);
-    }
-    
-    private int serverPort;
-    public int ServerPort
-    {
-        get => serverPort;
-        set => this.RaiseAndSetIfChanged(ref serverPort, value);
-    }
-    
-    private bool autoPortForward;
-    public bool AutoPortForward
-    {
-        get => autoPortForward;
-        set => this.RaiseAndSetIfChanged(ref autoPortForward, value);
-    }
-    
-    private bool allowLanDiscovery;
-    public bool AllowLanDiscovery
-    {
-        get => allowLanDiscovery;
-        set => this.RaiseAndSetIfChanged(ref allowLanDiscovery, value);
-    }
-    
-    private bool enableCommands;
-    public bool EnableCommands
-    {
-        get => enableCommands;
-        set => this.RaiseAndSetIfChanged(ref enableCommands, value);
-    }
-
     private string worldFolderDirectory;
     
     public ReactiveCommand<Unit, IRoutableViewModel> BackCommand { get; init; }
@@ -122,26 +29,9 @@ public class ManageServerViewModel : RoutableViewModelBase
         this.BindValidation();
         BackCommand = Router.NavigateBack;
     }
-
     public void LoadFrom(ServerEntry serverEntry)
     {
         Server = serverEntry;
-        worldFolderDirectory = Server.SavePath;
-
-        ServerIsOnline = Server.IsOnline;
-        
-        ServerName = Server.Name;
-        ServerPassword = Server.Password;
-        ServerGameMode = Server.GameMode;
-        ServerSeed = Server.Seed;
-        ServerDefaultPerms = Server.DefaultPlayerPerm;
-        ServerAutoSaveInterval = Server.AutoSaveInterval;
-        ServerPlayerLimit = Server.MaxPlayers;
-        ServerPlayerCount = Server.Players;
-        ServerPort = Server.Port;
-        AutoPortForward = Server.AutoPortForward;
-        AllowLanDiscovery = Server.AllowLanDiscovery;
-        EnableCommands = Server.AllowCommands;
-
+        worldFolderDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox", "saves", Server.Name);
     }
 }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -34,6 +34,28 @@ public class ManageServerViewModel : RoutableViewModelBase
         get => serverGameMode;
         set => this.RaiseAndSetIfChanged(ref serverGameMode, value);
     }
+    
+    private string serverSeed;
+    public string ServerSeed
+    {
+        get => serverSeed;
+        set => this.RaiseAndSetIfChanged(ref serverSeed, value);
+    }
+    
+    private int serverPlayerLimit;
+    public int ServerPlayerLimit
+    {
+        get => serverPlayerLimit;
+        set => this.RaiseAndSetIfChanged(ref serverPlayerLimit, value);
+    }
+    
+    private int serverPort;
+    public int ServerPort
+    {
+        get => serverPort;
+        set => this.RaiseAndSetIfChanged(ref serverPort, value);
+    }
+    
     public ReactiveCommand<Unit, IRoutableViewModel> BackCommand { get; init; }
 
     public ManageServerViewModel(IScreen hostScreen) : base(hostScreen)
@@ -45,7 +67,11 @@ public class ManageServerViewModel : RoutableViewModelBase
     public void LoadFrom(ServerEntry server)
     {
         ServerName = server.Name;
-        ServerPassword = ""; // Need to add password config
+        ServerPassword = ""; // Need to add
         ServerGameMode = server.GameMode;
+        serverSeed = ""; // Need to add
+
+        serverPlayerLimit = server.MaxPlayers;
+        serverPort = 11000; // Need to add
     }
 }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -8,6 +8,21 @@ namespace Nitrox.Launcher.ViewModels;
 
 public class ManageServerViewModel : RoutableViewModelBase
 {
+    private ServerEntry server;
+    public ServerEntry Server
+    {
+        get => server;
+        set => this.RaiseAndSetIfChanged(ref server, value);
+    }
+    
+    
+    private bool serverIsOnline;
+    public bool ServerIsOnline
+    {
+        get => serverIsOnline;
+        set => this.RaiseAndSetIfChanged(ref serverIsOnline, value);
+    }
+    
     private string serverName;
     /// <summary>
     ///     When set, navigates to the <see cref="ManageServerView" />.
@@ -42,11 +57,32 @@ public class ManageServerViewModel : RoutableViewModelBase
         set => this.RaiseAndSetIfChanged(ref serverSeed, value);
     }
     
+    private PlayerPermissions serverDefaultPerms;
+    public PlayerPermissions ServerDefaultPerms
+    {
+        get => serverDefaultPerms;
+        set => this.RaiseAndSetIfChanged(ref serverDefaultPerms, value);
+    }
+    
+    private int serverAutoSaveInterval;
+    public int ServerAutoSaveInterval
+    {
+        get => serverAutoSaveInterval;
+        set => this.RaiseAndSetIfChanged(ref serverAutoSaveInterval, value);
+    }
+    
     private int serverPlayerLimit;
     public int ServerPlayerLimit
     {
         get => serverPlayerLimit;
         set => this.RaiseAndSetIfChanged(ref serverPlayerLimit, value);
+    }
+    
+    private int serverPlayerCount;
+    public int ServerPlayerCount
+    {
+        get => serverPlayerCount;
+        set => this.RaiseAndSetIfChanged(ref serverPlayerCount, value);
     }
     
     private int serverPort;
@@ -56,6 +92,29 @@ public class ManageServerViewModel : RoutableViewModelBase
         set => this.RaiseAndSetIfChanged(ref serverPort, value);
     }
     
+    private bool autoPortForward;
+    public bool AutoPortForward
+    {
+        get => autoPortForward;
+        set => this.RaiseAndSetIfChanged(ref autoPortForward, value);
+    }
+    
+    private bool allowLanDiscovery;
+    public bool AllowLanDiscovery
+    {
+        get => allowLanDiscovery;
+        set => this.RaiseAndSetIfChanged(ref allowLanDiscovery, value);
+    }
+    
+    private bool enableCommands;
+    public bool EnableCommands
+    {
+        get => enableCommands;
+        set => this.RaiseAndSetIfChanged(ref enableCommands, value);
+    }
+
+    private string worldFolderDirectory;
+    
     public ReactiveCommand<Unit, IRoutableViewModel> BackCommand { get; init; }
 
     public ManageServerViewModel(IScreen hostScreen) : base(hostScreen)
@@ -64,14 +123,25 @@ public class ManageServerViewModel : RoutableViewModelBase
         BackCommand = Router.NavigateBack;
     }
 
-    public void LoadFrom(ServerEntry server)
+    public void LoadFrom(ServerEntry serverEntry)
     {
-        ServerName = server.Name;
-        ServerPassword = ""; // Need to add
-        ServerGameMode = server.GameMode;
-        serverSeed = ""; // Need to add
+        Server = serverEntry;
+        worldFolderDirectory = Server.SavePath;
 
-        serverPlayerLimit = server.MaxPlayers;
-        serverPort = 11000; // Need to add
+        ServerIsOnline = Server.IsOnline;
+        
+        ServerName = Server.Name;
+        ServerPassword = Server.Password;
+        ServerGameMode = Server.GameMode;
+        ServerSeed = Server.Seed;
+        ServerDefaultPerms = Server.DefaultPlayerPerm;
+        ServerAutoSaveInterval = Server.AutoSaveInterval;
+        ServerPlayerLimit = Server.MaxPlayers;
+        ServerPlayerCount = Server.Players;
+        ServerPort = Server.Port;
+        AutoPortForward = Server.AutoPortForward;
+        AllowLanDiscovery = Server.AllowLanDiscovery;
+        EnableCommands = Server.AllowCommands;
+
     }
 }

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Reactive;
 using System.Reactive.Linq;
 using DynamicData.Binding;
-using Microsoft.VisualBasic.FileIO;
 using Nitrox.Launcher.Models;
 using Nitrox.Launcher.ViewModels.Abstract;
 using Nitrox.Launcher.Views;
@@ -17,7 +16,7 @@ namespace Nitrox.Launcher.ViewModels;
 public class ManageServerViewModel : RoutableViewModelBase
 {
     public static Array PlayerPerms => Enum.GetValues(typeof(PlayerPermissions));
-    
+
 
     private ServerEntry server;
     /// <summary>
@@ -39,15 +38,15 @@ public class ManageServerViewModel : RoutableViewModelBase
             }
         }
     }
-    
+
     private bool serverIsOnline;
     public bool ServerIsOnline
     {
         get => Server.IsOnline;
         set => this.RaiseAndSetIfChanged(ref serverIsOnline, value);
     }
-    
-    
+
+
     private string serverName;
     public string ServerName
     {
@@ -124,18 +123,18 @@ public class ManageServerViewModel : RoutableViewModelBase
         get => serverAllowLanDiscovery;
         set => this.RaiseAndSetIfChanged(ref serverAllowLanDiscovery, value);
     }
-    
+
     private bool serverAllowCommands;
     public bool ServerAllowCommands
     {
         get => serverAllowCommands;
         set => this.RaiseAndSetIfChanged(ref serverAllowCommands, value);
     }
-    
-    
+
+
     private string worldFolderDirectory;
-    
-    
+
+
     private bool HasChanges()
     {
         if (Server == null)
@@ -155,12 +154,12 @@ public class ManageServerViewModel : RoutableViewModelBase
                ServerAllowLanDiscovery != Server.AllowLanDiscovery ||
                ServerAllowCommands != Server.AllowCommands;
     }
-    
+
     public ReactiveCommand<Unit, Unit> BackCommand { get; init; }
     public ReactiveCommand<Unit, Unit> SaveCommand { get; init; }
     public ReactiveCommand<Unit, Unit> UndoCommand { get; init; }
     public ReactiveCommand<Unit, Unit> StartServerCommand { get; init; }
-    
+
     public ReactiveCommand<Unit, Unit> AdvancedSettingsCommand { get; init; }
     public ReactiveCommand<Unit, Unit> OpenWorldFolderCommand { get; init; }
     public ReactiveCommand<Unit, Unit> RestoreBackupCommand { get; init; }
@@ -173,14 +172,14 @@ public class ManageServerViewModel : RoutableViewModelBase
         IObservable<bool> canExecuteSaveCommand = this.WhenAnyPropertyChanged().CombineLatest(Observable.Return(this), this.IsValid()).Select(pair => pair.Second.HasChanges() && pair.Third);
         IObservable<bool> canExecuteUndoCommand = this.WhenAnyPropertyChanged().Select(x => x.HasChanges());
         IObservable<bool> canExecuteManageServerCommands = this.WhenAnyPropertyChanged().Select(x => !x.HasChanges());
-        
+
         IObservable<bool> canExecuteAdvancedSettingsButtonCommands = this.WhenAnyPropertyChanged().Select(x => !x.ServerIsOnline);
-        
+
         BackCommand = ReactiveCommand.Create(() =>
         {
             Router.NavigateBack.Execute();
         }, canExecuteManageServerCommands);
-        
+
         SaveCommand = ReactiveCommand.Create(() =>
         {
             Server.Name = ServerName;
@@ -197,7 +196,7 @@ public class ManageServerViewModel : RoutableViewModelBase
             Server.AllowCommands = ServerAllowCommands;
             this.RaisePropertyChanged(nameof(Server));
         }, canExecuteSaveCommand);
-        
+
         UndoCommand = ReactiveCommand.Create(() =>
         {
             ServerName = Server.Name;
@@ -213,49 +212,40 @@ public class ManageServerViewModel : RoutableViewModelBase
             ServerAllowLanDiscovery = Server.AllowLanDiscovery;
             ServerAllowCommands = Server.AllowCommands;
         }, canExecuteUndoCommand);
-        
+
         StartServerCommand = ReactiveCommand.Create(() =>
         {
             Server.StartCommand.Execute(null);
         }, canExecuteManageServerCommands);
-        
-        
+
+
         AdvancedSettingsCommand = ReactiveCommand.Create(() =>
         {
             // TODO: Open Advanced Settings Popup (which is automatically populated with the rest of the server.cfg settings)
         });
-        
+
         OpenWorldFolderCommand = ReactiveCommand.Create(() =>
         {
             Process.Start(worldFolderDirectory)?.Dispose(); // TODO: Fix file access permission issues
         });
-        
+
         RestoreBackupCommand = ReactiveCommand.Create(() =>
         {
             // TODO: Open Restore Backup Popup
         }, canExecuteAdvancedSettingsButtonCommands);
-        
+
         DeleteServerCommand = ReactiveCommand.Create(() =>
         {
-            // TODO: Handle this for other platforms (probably only works on Windows)
-            try
-            {
-                FileSystem.DeleteDirectory(worldFolderDirectory, UIOption.OnlyErrorDialogs, RecycleOption.SendToRecycleBin);
-                //Log.Info($"Moving world \"{Path.GetFileName(worldFolderDirectory)}\" to the recycling bin.");
-            }
-            catch (Exception ex)
-            {
-                //Log.Error($"Could not move save \"{Path.GetFileName(worldFolderDirectory)}\" to the recycling bin : {ex.GetType()} {ex.Message}");
-            }
+            // TODO: Delete this specific server's files
         }, canExecuteAdvancedSettingsButtonCommands);
     }
     public void LoadFrom(ServerEntry serverEntry)
     {
         Server = serverEntry;
         worldFolderDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Nitrox", "saves", Server.Name);
-        
+
         ServerIsOnline = Server.IsOnline;
-        
+
         ServerName = Server.Name;
         ServerPassword = Server.Password;
         ServerGameMode = Server.GameMode;
@@ -269,7 +259,7 @@ public class ManageServerViewModel : RoutableViewModelBase
         ServerAllowLanDiscovery = Server.AllowLanDiscovery;
         ServerAllowCommands = Server.AllowCommands;
     }
-    
+
     private void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)
     {
         if (e.PropertyName == nameof(ServerEntry.IsOnline))

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.IO;
 using System.Reactive;
+using System.Reactive.Linq;
 using Nitrox.Launcher.Models;
 using Nitrox.Launcher.ViewModels.Abstract;
 using Nitrox.Launcher.Views;
@@ -126,14 +127,34 @@ public class ManageServerViewModel : RoutableViewModelBase
     private string worldFolderDirectory;
     
     public ReactiveCommand<Unit, Unit> BackCommand { get; init; }
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; init; }
 
     public ManageServerViewModel(IScreen hostScreen) : base(hostScreen)
     {
         this.BindValidation();
+        
         BackCommand = ReactiveCommand.Create(() =>
         {
-            Save();
+            Save(); // TEMP - Will be replaced by Save button/command (below)
             Router.NavigateBack.Execute();
+        });
+        
+        SaveCommand = ReactiveCommand.Create(() =>
+        {
+            Server.WhenAnyValue(x => x.IsOnline).Where(x => !x);
+            
+            Server.Name = ServerName;
+            Server.Password = ServerPassword;
+            Server.GameMode = ServerGameMode;
+            Server.Seed = ServerSeed;
+            Server.DefaultPlayerPerm = ServerDefaultPlayerPerm;
+            Server.AutoSaveInterval = ServerAutoSaveInterval;
+            Server.MaxPlayers = ServerMaxPlayers;
+            Server.Players = ServerPlayers;
+            Server.Port = ServerPort;
+            Server.AutoPortForward = ServerAutoPortForward;
+            Server.AllowLanDiscovery = ServerAllowLanDiscovery;
+            Server.AllowCommands = ServerAllowCommands;
         });
     }
     public void LoadFrom(ServerEntry serverEntry)
@@ -157,7 +178,7 @@ public class ManageServerViewModel : RoutableViewModelBase
         ServerAllowCommands = Server.AllowCommands;
     }
 
-    private void Save()
+    private void Save() // TEMP - Will be replaced
     {
         // TODO: Check for invalid value inputs and throw an error if one is found
         

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -13,8 +13,9 @@ namespace Nitrox.Launcher.ViewModels;
 
 public class ManageServerViewModel : RoutableViewModelBase
 {
-    public Array PlayerPerms = Enum.GetValues(typeof(PlayerPermissions));
+    public static Array PlayerPerms => Enum.GetValues(typeof(PlayerPermissions));
     
+
     private ServerEntry server;
     /// <summary>
     ///     When set, navigates to the <see cref="ManageServerView" />.
@@ -22,7 +23,7 @@ public class ManageServerViewModel : RoutableViewModelBase
     public ServerEntry Server
     {
         get => server;
-        set
+        private set
         {
             if (server != null)
             {
@@ -43,7 +44,8 @@ public class ManageServerViewModel : RoutableViewModelBase
         get => Server.IsOnline;
         set => this.RaiseAndSetIfChanged(ref serverIsOnline, value);
     }
-
+    
+    
     private string serverName;
     public string ServerName
     {
@@ -176,6 +178,7 @@ public class ManageServerViewModel : RoutableViewModelBase
         }
     }
     
+    
     private string worldFolderDirectory;
 
     private bool isAnySettingChanged;
@@ -192,7 +195,8 @@ public class ManageServerViewModel : RoutableViewModelBase
         get => isChangedSettingsValid;
         set => this.RaiseAndSetIfChanged(ref isChangedSettingsValid, value);
     }
-
+    
+    
     private void CheckIfAnySettingChanged()
     {
         if (ServerName != Server.Name || ServerPassword != Server.Password ||

--- a/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ManageServerViewModel.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.ComponentModel;
 using System.IO;
-using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
+using DynamicData.Binding;
 using Nitrox.Launcher.Models;
 using Nitrox.Launcher.ViewModels.Abstract;
 using Nitrox.Launcher.Views;
 using ReactiveUI;
+using ReactiveUI.Validation.Extensions;
 
 namespace Nitrox.Launcher.ViewModels;
 
@@ -34,7 +35,6 @@ public class ManageServerViewModel : RoutableViewModelBase
             {
                 server.PropertyChanged += Server_PropertyChanged;
             }
-            CheckIfAnySettingChanged();
         }
     }
     
@@ -50,174 +50,108 @@ public class ManageServerViewModel : RoutableViewModelBase
     public string ServerName
     {
         get => serverName;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverName, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverName, value);
     }
 
     private string serverPassword;
     public string ServerPassword
     {
         get => serverPassword;
-        set
-        { 
-            this.RaiseAndSetIfChanged(ref serverPassword, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverPassword, value);
     }
 
     private GameMode serverGameMode;
     public GameMode ServerGameMode
     {
         get => serverGameMode;
-        set
-        {
-            this.RaiseAndSetIfChanged( ref serverGameMode, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged( ref serverGameMode, value);
     }
 
     private string serverSeed;
     public string ServerSeed
     {
         get => serverSeed;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverSeed, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverSeed, value);
     }
 
     private PlayerPermissions serverDefaultPlayerPerm;
     public PlayerPermissions ServerDefaultPlayerPerm
     {
         get => serverDefaultPlayerPerm;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverDefaultPlayerPerm, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverDefaultPlayerPerm, value);
     }
 
     private int serverAutoSaveInterval;
     public int ServerAutoSaveInterval
     {
         get => serverAutoSaveInterval;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverAutoSaveInterval, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverAutoSaveInterval, value);
     }
 
     private int serverMaxPlayers;
     public int ServerMaxPlayers
     {
         get => serverMaxPlayers;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverMaxPlayers, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverMaxPlayers, value);
     }
 
     private int serverPlayers;
     public int ServerPlayers
     {
         get => serverPlayers;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverPlayers, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverPlayers, value);
     }
 
     private int serverPort;
     public int ServerPort
     {
         get => serverPort;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverPort, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverPort, value);
     }
 
     private bool serverAutoPortForward;
     public bool ServerAutoPortForward
     {
         get => serverAutoPortForward;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverAutoPortForward, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverAutoPortForward, value);
     }
 
     private bool serverAllowLanDiscovery;
     public bool ServerAllowLanDiscovery
     {
         get => serverAllowLanDiscovery;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverAllowLanDiscovery, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverAllowLanDiscovery, value);
     }
     
     private bool serverAllowCommands;
     public bool ServerAllowCommands
     {
         get => serverAllowCommands;
-        set
-        {
-            this.RaiseAndSetIfChanged(ref serverAllowCommands, value);
-            CheckIfAnySettingChanged();
-        }
+        set => this.RaiseAndSetIfChanged(ref serverAllowCommands, value);
     }
     
     
     private string worldFolderDirectory;
-
-    private bool isAnySettingChanged;
-    public bool IsAnySettingChanged
-    {
-        get => isAnySettingChanged;
-        set => this.RaiseAndSetIfChanged(ref isAnySettingChanged, value);
-    }
-    
-    private bool isChangedSettingsValid;
-
-    public bool IsChangedSettingsValid
-    {
-        get => isChangedSettingsValid;
-        set => this.RaiseAndSetIfChanged(ref isChangedSettingsValid, value);
-    }
     
     
-    private void CheckIfAnySettingChanged()
+    private bool HasChanges()
     {
-        if (ServerName != Server.Name || ServerPassword != Server.Password ||
-            ServerGameMode != Server.GameMode || ServerSeed != Server.Seed ||
-            ServerDefaultPlayerPerm != Server.DefaultPlayerPerm || ServerAutoSaveInterval != Server.AutoSaveInterval ||
-            ServerMaxPlayers != Server.MaxPlayers || ServerPlayers != Server.Players ||
-            ServerPort != Server.Port || ServerAutoPortForward != Server.AutoPortForward ||
-            ServerAllowLanDiscovery != Server.AllowLanDiscovery || ServerAllowCommands != Server.AllowCommands)
+        if (Server == null)
         {
-            IsAnySettingChanged = true;
-
-            if (string.IsNullOrEmpty(ServerName) || ServerName.Any(c => Path.GetInvalidFileNameChars().Contains(c)))
-                IsChangedSettingsValid = false;
-            else
-                IsChangedSettingsValid = true;
+            return false;
         }
-        else
-        {
-            IsAnySettingChanged = false;
-            IsChangedSettingsValid = true;
-        }
+        return ServerName != Server.Name ||
+               ServerPassword != Server.Password ||
+               ServerGameMode != Server.GameMode ||
+               ServerSeed != Server.Seed ||
+               ServerDefaultPlayerPerm != Server.DefaultPlayerPerm ||
+               ServerAutoSaveInterval != Server.AutoSaveInterval ||
+               ServerMaxPlayers != Server.MaxPlayers ||
+               ServerPlayers != Server.Players ||
+               ServerPort != Server.Port ||
+               ServerAutoPortForward != Server.AutoPortForward ||
+               ServerAllowLanDiscovery != Server.AllowLanDiscovery ||
+               ServerAllowCommands != Server.AllowCommands;
     }
     
     public ReactiveCommand<Unit, Unit> BackCommand { get; init; }
@@ -228,12 +162,10 @@ public class ManageServerViewModel : RoutableViewModelBase
     public ManageServerViewModel(IScreen hostScreen) : base(hostScreen)
     {
         this.BindValidation();
-        
-        IObservable<bool> canExecuteSaveCommand = this.WhenAnyValue(x => x.IsAnySettingChanged, x => x.IsChangedSettingsValid,
-                                                                    (settingsAreChanged, noInvalidChanges)
-                                                                        => settingsAreChanged && noInvalidChanges);
-        IObservable<bool> canExecuteUndoCommand = this.WhenAnyValue(x => x.IsAnySettingChanged);
-        IObservable<bool> canExecuteManageServerCommands = this.WhenAnyValue(x => x.IsAnySettingChanged, (value) => !value);
+
+        IObservable<bool> canExecuteSaveCommand = this.WhenAnyPropertyChanged().CombineLatest(Observable.Return(this), this.IsValid()).Select(pair => pair.Second.HasChanges() && pair.Third);
+        IObservable<bool> canExecuteUndoCommand = this.WhenAnyPropertyChanged().Select(x => x.HasChanges());
+        IObservable<bool> canExecuteManageServerCommands = this.WhenAnyPropertyChanged().Select(x => !x.HasChanges());
         
         BackCommand = ReactiveCommand.Create(() =>
         {
@@ -242,12 +174,10 @@ public class ManageServerViewModel : RoutableViewModelBase
         
         SaveCommand = ReactiveCommand.Create(() =>
         {
-            Server.WhenAnyValue(x => x.IsOnline).Where(x => !x);
-            
             Server.Name = ServerName;
             Server.Password = ServerPassword;
             Server.GameMode = ServerGameMode;
-            Server.Seed = ServerSeed;
+            Server.Seed = ServerSeed;//.ToUpper();
             Server.DefaultPlayerPerm = ServerDefaultPlayerPerm;
             Server.AutoSaveInterval = ServerAutoSaveInterval;
             Server.MaxPlayers = ServerMaxPlayers;
@@ -256,8 +186,7 @@ public class ManageServerViewModel : RoutableViewModelBase
             Server.AutoPortForward = ServerAutoPortForward;
             Server.AllowLanDiscovery = ServerAllowLanDiscovery;
             Server.AllowCommands = ServerAllowCommands;
-            
-            CheckIfAnySettingChanged();
+            this.RaisePropertyChanged(nameof(Server));
         }, canExecuteSaveCommand);
         
         UndoCommand = ReactiveCommand.Create(() =>
@@ -300,8 +229,6 @@ public class ManageServerViewModel : RoutableViewModelBase
         ServerAutoPortForward = Server.AutoPortForward;
         ServerAllowLanDiscovery = Server.AllowLanDiscovery;
         ServerAllowCommands = Server.AllowCommands;
-        
-        CheckIfAnySettingChanged();
     }
     
     private void Server_PropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Nitrox.Launcher/ViewModels/ServersViewModel.cs
+++ b/Nitrox.Launcher/ViewModels/ServersViewModel.cs
@@ -9,6 +9,7 @@ namespace Nitrox.Launcher.ViewModels;
 public class ServersViewModel : RoutableViewModelBase
 {
     public ICommand CreateServerCommand { get; }
+    public ICommand ManageServerCommand { get; }
     public AvaloniaList<ServerEntry> Servers { get; } = new();
 
     public ServersViewModel(IScreen hostScreen) : base(hostScreen)
@@ -23,6 +24,12 @@ public class ServersViewModel : RoutableViewModelBase
 
             AddServer(result.Name, result.SelectedGameMode);
         });
+        ManageServerCommand = ReactiveCommand.Create((ServerEntry server) =>
+        {
+            ManageServerViewModel viewModel = Locator.GetSharedViewModel<ManageServerViewModel>();
+            viewModel.LoadFrom(server);
+            MainViewModel.Router.Navigate.Execute(viewModel);
+        });
 
         // TODO: Load servers from file
     }
@@ -32,13 +39,7 @@ public class ServersViewModel : RoutableViewModelBase
         Servers.Add(new ServerEntry
         {
             Name = name,
-            GameMode = gameMode,
-            ManageCommand = ReactiveCommand.Create((ServerEntry server) =>
-            {
-                ManageServerViewModel viewModel = Locator.GetSharedViewModel<ManageServerViewModel>();
-                viewModel.LoadFrom(server);
-                MainViewModel.Router.Navigate.Execute(viewModel);
-            })
+            GameMode = gameMode
         });
     }
 }

--- a/Nitrox.Launcher/Views/CreateServerModal.axaml
+++ b/Nitrox.Launcher/Views/CreateServerModal.axaml
@@ -19,7 +19,7 @@
             <TextBlock Text="Create a server" Classes="modalHeader" />
             <StackPanel>
                 <TextBlock Text="SERVER NAME" />
-                <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding Name}" />
+                <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding Name}" MaxWidth="366"/>
             </StackPanel>
             <StackPanel>
                 <TextBlock Text="GAMEMODE" />

--- a/Nitrox.Launcher/Views/CreateServerModal.axaml
+++ b/Nitrox.Launcher/Views/CreateServerModal.axaml
@@ -19,7 +19,7 @@
             <TextBlock Text="Create a server" Classes="modalHeader" />
             <StackPanel>
                 <TextBlock Text="SERVER NAME" />
-                <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding Name}" MaxWidth="366"/>
+                <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding Name}" MaxWidth="400" MaxLength="120" />
             </StackPanel>
             <StackPanel>
                 <TextBlock Text="GAMEMODE" />

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -104,7 +104,13 @@
                         <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Server seed" Text="{Binding ServerSeed}"
                                  MaxLength="10" IsEnabled="{Binding !ServerIsOnline}"
-                                 IsReadOnly="{Binding !Server.IsNewServer}"/>
+                                 IsReadOnly="{Binding !Server.IsNewServer}">
+                            <TextBox.Styles>
+                                <Style Selector="TextBox[IsReadOnly=True]">
+                                    <Setter Property="ToolTip.Tip" Value="Seed cannot be changed for servers that have been run." />
+                                </Style>
+                            </TextBox.Styles>
+                        </TextBox>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
@@ -133,16 +139,16 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerMaxPlayers, FallbackValue=100}"
+                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerMaxPlayers, Converter={converters:IntToStringConverter}}"
                                  IsEnabled="{Binding !ServerIsOnline}"
                                  KeyDown="InputElement_OnKeyDown" MaxLength="9"/>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"
+                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, Converter={converters:IntToStringConverter}}"
                                  IsEnabled="{Binding !ServerIsOnline}"
-                                 KeyDown="InputElement_OnKeyDown" MaxLength="9"/>
+                                 KeyDown="InputElement_OnKeyDown" MaxLength="5"/>
                     </StackPanel>
                 </Grid>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -81,11 +81,8 @@
                 
                 <StackPanel>
                     <TextBlock Text="OPTIONS" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 15" />
-                    <StackPanel>
+                    <StackPanel Spacing="20">
                         <StackPanel.Styles>
-                            <Style Selector="StackPanel > Grid">
-                                <Setter Property="Margin" Value="0 0 0 20"/>
-                            </Style>
                             <Style Selector="Grid > TextBlock">
                                 <Setter Property="FontSize" Value="16"/>
                                 <Setter Property="FontWeight" Value="400"/>
@@ -104,6 +101,31 @@
                             <TextBlock Text="Enable Commands"/>
                             <CheckBox Classes="switch" IsChecked="True" HorizontalAlignment="Right"/>
                         </Grid>
+                    </StackPanel>
+                </StackPanel>
+                
+                <StackPanel>
+                    <TextBlock Text="ADVANCED" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 20" />
+                    <StackPanel Spacing="20">
+                        <StackPanel.Styles>
+                            <Style Selector="Button">
+                                <Setter Property="FontSize" Value="16"/>
+                                <Setter Property="FontWeight" Value="400"/>
+                            </Style>
+                        </StackPanel.Styles> 
+                        
+                        <Button Classes="textimage"
+                                design:NitroxAttached.Image="/Assets/Images/world-manager/window-external-2x.png"
+                                design:NitroxAttached.Text="Open world folder"/>
+                        
+                        <Button Classes="textimage"
+                                design:NitroxAttached.Image="/Assets/Images/world-manager/export-2x.png"
+                                design:NitroxAttached.Text="Import backup"/>
+                        
+                        <Button Classes="textimage" 
+                                design:NitroxAttached.Image="/Assets/Images/world-manager/delete-2x.png"
+                                design:NitroxAttached.Text="Delete server" Foreground="#ec1c24"/>
+                        
                     </StackPanel>
                 </StackPanel>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -189,21 +189,23 @@
                         
                         <Button Classes="textimage"
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/cog-2x.png"
-                                design:NitroxAttached.Text="Advanced settings"/>
+                                design:NitroxAttached.Text="Advanced settings"
+                                Command="{Binding AdvancedSettingsCommand}"/>
                         
                         <Button Classes="textimage"
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/window-external-2x.png"
-                                design:NitroxAttached.Text="Open world folder"/>
+                                design:NitroxAttached.Text="Open world folder"
+                                Command="{Binding OpenWorldFolderCommand}"/>
                         
                         <Button Classes="textimage"
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/export-2x.png"
                                 design:NitroxAttached.Text="Restore a backup"
-                                IsEnabled="{Binding !ServerIsOnline}"/>
+                                Command="{Binding RestoreBackupCommand}"/>
                         
                         <Button Classes="textimage" 
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/delete-2x.png"
                                 design:NitroxAttached.Text="Delete server" Foreground="#ec1c24"
-                                IsEnabled="{Binding !ServerIsOnline}"/>
+                                Command="{Binding DeleteServerCommand}"/> <!-- IsEnabled="{Binding !ServerIsOnline}" -->
                         
                     </StackPanel>
                 </StackPanel>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -37,25 +37,25 @@
                     </Style>
                 </StackPanel.Styles>
                 <Panel>
-                    <StackPanel Orientation="Horizontal" IsVisible="{Binding Server.IsOnline}">
+                    <StackPanel Orientation="Horizontal" IsVisible="{Binding ServerIsOnline}">
                         <Ellipse Margin="0 0 6 0" Fill="#38C149" />
-                        <TextBlock IsVisible="{Binding Server.IsOnline}" Text="Online" />
+                        <TextBlock IsVisible="{Binding ServerIsOnline}" Text="Online" />
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" IsVisible="{Binding !Server.IsOnline}">
+                    <StackPanel Orientation="Horizontal" IsVisible="{Binding !ServerIsOnline}">
                         <Ellipse Margin="0 0 6 0" Fill="#FF5E57" />
-                        <TextBlock IsVisible="{Binding !Server.IsOnline}" Text="Offline" />
+                        <TextBlock IsVisible="{Binding !ServerIsOnline}" Text="Offline" />
                     </StackPanel>
                 </Panel>
-                <TextBlock Text="{Binding Server.GameMode, Converter={converters:ToStringConverter}}" />
+                <TextBlock Text="{Binding ServerGameMode, Converter={converters:ToStringConverter}}" />
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding Server.Players}" />
+                    <TextBlock Text="{Binding ServerPlayers}" />
                     <TextBlock Text="/" />
-                    <TextBlock Text="{Binding Server.MaxPlayers}" />
+                    <TextBlock Text="{Binding ServerMaxPlayers}" />
                     <TextBlock Margin="6 0 0 0" Text="playing" />
                 </StackPanel>
             </StackPanel>
             
-            <TextBlock Classes="header" Text="{Binding Server.Name}" />
+            <TextBlock Classes="header" Text="{Binding ServerName}" />
         </StackPanel>
         
         <ScrollViewer Grid.Row="1">
@@ -69,38 +69,40 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding Server.Name}" />
+                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server password" Text="{Binding Server.Password}" PasswordChar="●"/>
+                        <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"/>
                     </StackPanel>
                 </Grid>
         
                 <StackPanel>
                     <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" />
-                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding Server.GameMode, Mode=TwoWay}" />
+                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding ServerGameMode, Mode=TwoWay}" />
                 </StackPanel>
                 
                 <Grid ColumnDefinitions="*,30,*,30,*">
                     <StackPanel>
                         <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server seed" Text="{Binding Server.Seed}" />
+                        <TextBox Watermark="Server seed" Text="{Binding ServerSeed}" MaxLength="10" />
                     </StackPanel>
+                    
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Might need to use converters here -->
-                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding Server.DefaultPlayerPerm}">
+                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerDefaultPlayerPerm}">
                             <ComboBoxItem Content="Player" Tag="PLAYER"/>
                             <ComboBoxItem Content="Operator" Tag="OPERATOR"/>
                             <ComboBoxItem Content="Admin" Tag="ADMIN"/>
                         </ComboBox>
                     </StackPanel>
+                    
                     <StackPanel Grid.Column="4">
                         <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Handle values other than the preset ones by binding data directly to the ComboBox's TextBox -->
-                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding Server.AutoSaveInterval}">
+                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerAutoSaveInterval}">
                             <ComboBoxItem Content="60s" Tag="60"/>
                             <ComboBoxItem Content="120s" Tag="120"/>
                             <ComboBoxItem Content="240s" Tag="240"/>
@@ -113,12 +115,12 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a player limit" Text="{Binding Server.MaxPlayers, FallbackValue=100}" />
+                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerMaxPlayers, FallbackValue=100}" />
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a port number" Text="{Binding Server.Port, FallbackValue=11000}"/>
+                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"/>
                     </StackPanel>
                 </Grid>
                 
@@ -134,15 +136,15 @@
                         </StackPanel.Styles> 
                         <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding Server.AutoPortForward}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAutoPortForward}" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding Server.AllowLanDiscovery}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowLanDiscovery}" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Enable Commands"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding Server.AllowCommands}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowCommands}" HorizontalAlignment="Right"/>
                         </Grid>
                     </StackPanel>
                 </StackPanel>
@@ -183,12 +185,12 @@
                             <RadioButton >External console</RadioButton>
                         </StackPanel>
                         
-                        <Button Grid.Column="1" Classes="nitrox abort big" IsVisible="{Binding Server.IsOnline}"
+                        <Button Grid.Column="1" Classes="nitrox abort big" IsVisible="{Binding ServerIsOnline}"
                                 VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
-                                design:NitroxAttached.Text="STOP SERVER" Command="{Binding Server.StopCommand}" /> <!-- Sort of works -->
-                        <Button Grid.Column="1" Classes="nitrox primary big" IsVisible="{Binding !Server.IsOnline}"
+                                design:NitroxAttached.Text="STOP SERVER" Command="{Binding Server.StopCommand}" />
+                        <Button Grid.Column="1" Classes="nitrox primary big" IsVisible="{Binding !ServerIsOnline}"
                                 VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
-                                design:NitroxAttached.Text="START SERVER" design:NitroxAttached.Subtext="MULTIPLAYER" Command="{Binding Server.StartCommand}" /> <!-- Sort of works -->
+                                design:NitroxAttached.Text="START SERVER" design:NitroxAttached.Subtext="MULTIPLAYER" Command="{Binding Server.StartCommand}" />
                     </Grid>
                 </Border>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -69,30 +69,37 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
+                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}"
+                                 IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"/>
+                        <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"
+                                 IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                 </Grid>
         
                 <StackPanel>
                     <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" />
-                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding ServerGameMode, Mode=TwoWay}" />
+                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}"
+                                               SelectedItem="{Binding ServerGameMode, Mode=TwoWay}"
+                                               IsEnabled="{Binding !ServerIsOnline}"/>
                 </StackPanel>
                 
                 <Grid ColumnDefinitions="*,30,*,30,*">
                     <StackPanel>
                         <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server seed" Text="{Binding ServerSeed}" MaxLength="10" />
+                        <TextBox Watermark="Server seed" Text="{Binding ServerSeed}"
+                                 MaxLength="10" IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Might need to use converters here -->
-                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerDefaultPlayerPerm}">
+                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch"
+                                  SelectedValueBinding="{Binding ServerDefaultPlayerPerm}"
+                                  IsEnabled="{Binding !ServerIsOnline}">
                             <ComboBoxItem Content="Player" Tag="PLAYER"/>
                             <ComboBoxItem Content="Operator" Tag="OPERATOR"/>
                             <ComboBoxItem Content="Admin" Tag="ADMIN"/>
@@ -102,7 +109,9 @@
                     <StackPanel Grid.Column="4">
                         <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Handle values other than the preset ones by binding data directly to the ComboBox's TextBox -->
-                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerAutoSaveInterval}">
+                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch"
+                                  SelectedValueBinding="{Binding ServerAutoSaveInterval}"
+                                  IsEnabled="{Binding !ServerIsOnline}">
                             <ComboBoxItem Content="60s" Tag="60"/>
                             <ComboBoxItem Content="120s" Tag="120"/>
                             <ComboBoxItem Content="240s" Tag="240"/>
@@ -115,12 +124,14 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerMaxPlayers, FallbackValue=100}" />
+                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerMaxPlayers, FallbackValue=100}"
+                                 IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"/>
+                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"
+                                 IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                 </Grid>
                 
@@ -136,15 +147,18 @@
                         </StackPanel.Styles> 
                         <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding ServerAutoPortForward}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAutoPortForward}" HorizontalAlignment="Right"
+                                      IsEnabled="{Binding !ServerIsOnline}"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowLanDiscovery}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowLanDiscovery}" HorizontalAlignment="Right"
+                                      IsEnabled="{Binding !ServerIsOnline}"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Enable Commands"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowCommands}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowCommands}" HorizontalAlignment="Right"
+                                      IsEnabled="{Binding !ServerIsOnline}"/>
                         </Grid>
                     </StackPanel>
                 </StackPanel>
@@ -169,18 +183,21 @@
                         
                         <Button Classes="textimage"
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/export-2x.png"
-                                design:NitroxAttached.Text="Restore a backup"/>
+                                design:NitroxAttached.Text="Restore a backup"
+                                IsEnabled="{Binding !ServerIsOnline}"/>
                         
                         <Button Classes="textimage" 
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/delete-2x.png"
-                                design:NitroxAttached.Text="Delete server" Foreground="#ec1c24"/>
+                                design:NitroxAttached.Text="Delete server" Foreground="#ec1c24"
+                                IsEnabled="{Binding !ServerIsOnline}"/>
                         
                     </StackPanel>
                 </StackPanel>
                 
                 <Border Background="#151516" CornerRadius="12" Height="96">
                     <Grid ColumnDefinitions="*,*" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                        <StackPanel  HorizontalAlignment="Left" VerticalAlignment="Center" Margin="26 0">
+                        <StackPanel  HorizontalAlignment="Left" VerticalAlignment="Center" Margin="26 0"
+                                     IsEnabled="{Binding !ServerIsOnline}">
                             <RadioButton IsChecked="True" >Docked console</RadioButton>
                             <RadioButton >External console</RadioButton>
                         </StackPanel>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -55,7 +55,17 @@
                 </StackPanel>
             </StackPanel>
             
-            <TextBlock Classes="header" Text="{Binding ServerName}" />
+            <Grid ColumnDefinitions="*,100,100">
+                <TextBlock Classes="header" Text="{Binding ServerName}" Margin="0 0 5 0" />
+                
+                <Button Grid.Column="1" Classes="nitrox big abort"
+                        Height="40" Margin="0 0 5 0" Padding="5" HorizontalAlignment="Stretch"
+                        design:NitroxAttached.Text="UNDO" Command="{Binding UndoCommand}" />
+                <Button Grid.Column="2" Classes="nitrox big"
+                        Height="40" Margin="5 0 0 0" Padding="5" HorizontalAlignment="Stretch"
+                        design:NitroxAttached.Text="SAVE" Command="{Binding SaveCommand}" />
+            </Grid>
+            
         </StackPanel>
         
         <ScrollViewer Grid.Row="1">
@@ -137,7 +147,7 @@
                 
                 <StackPanel>
                     <TextBlock Text="OPTIONS" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 15" />
-                    <StackPanel Spacing="20">
+                    <StackPanel Spacing="20" IsEnabled="{Binding !ServerIsOnline}">
                         <StackPanel.Styles>
                             <Style Selector="Grid > TextBlock">
                                 <Setter Property="FontSize" Value="16"/>
@@ -147,18 +157,15 @@
                         </StackPanel.Styles> 
                         <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding ServerAutoPortForward}" HorizontalAlignment="Right"
-                                      IsEnabled="{Binding !ServerIsOnline}"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAutoPortForward}" HorizontalAlignment="Right" />
                         </Grid>
                         <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowLanDiscovery}" HorizontalAlignment="Right"
-                                      IsEnabled="{Binding !ServerIsOnline}"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowLanDiscovery}" HorizontalAlignment="Right" />
                         </Grid>
                         <Grid>
                             <TextBlock Text="Enable Commands"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowCommands}" HorizontalAlignment="Right"
-                                      IsEnabled="{Binding !ServerIsOnline}"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding ServerAllowCommands}" HorizontalAlignment="Right" />
                         </Grid>
                     </StackPanel>
                 </StackPanel>
@@ -194,20 +201,20 @@
                     </StackPanel>
                 </StackPanel>
                 
-                <Border Background="#151516" CornerRadius="12" Height="96">
-                    <Grid ColumnDefinitions="*,*" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                        <StackPanel  HorizontalAlignment="Left" VerticalAlignment="Center" Margin="26 0"
+                <Border Background="#151516" CornerRadius="12" Height="96" Padding="25 17">
+                    <Grid ColumnDefinitions="Auto,*,*,3*" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <StackPanel  HorizontalAlignment="Left" VerticalAlignment="Center"
                                      IsEnabled="{Binding !ServerIsOnline}">
                             <RadioButton IsChecked="True" >Docked console</RadioButton>
                             <RadioButton >External console</RadioButton>
                         </StackPanel>
                         
-                        <Button Grid.Column="1" Classes="nitrox abort big" IsVisible="{Binding ServerIsOnline}"
-                                VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
+                        <Button Grid.Column="3" Classes="nitrox abort big" IsVisible="{Binding ServerIsOnline}"
+                                VerticalAlignment="Center" HorizontalAlignment="Stretch"
                                 design:NitroxAttached.Text="STOP SERVER" Command="{Binding Server.StopCommand}" />
-                        <Button Grid.Column="1" Classes="nitrox primary big" IsVisible="{Binding !ServerIsOnline}"
-                                VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
-                                design:NitroxAttached.Text="START SERVER" design:NitroxAttached.Subtext="MULTIPLAYER" Command="{Binding Server.StartCommand}" />
+                        <Button Grid.Column="3" Classes="nitrox primary big" IsVisible="{Binding !ServerIsOnline}"
+                                VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                                design:NitroxAttached.Text="START SERVER" design:NitroxAttached.Subtext="MULTIPLAYER" Command="{Binding StartServerCommand}" />
                     </Grid>
                 </Border>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -115,12 +115,16 @@
                         </StackPanel.Styles> 
                         
                         <Button Classes="textimage"
+                                design:NitroxAttached.Image="/Assets/Images/world-manager/cog-2x.png"
+                                design:NitroxAttached.Text="Advanced settings"/>
+                        
+                        <Button Classes="textimage"
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/window-external-2x.png"
                                 design:NitroxAttached.Text="Open world folder"/>
                         
                         <Button Classes="textimage"
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/export-2x.png"
-                                design:NitroxAttached.Text="Import backup"/>
+                                design:NitroxAttached.Text="Restore a backup"/>
                         
                         <Button Classes="textimage" 
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/delete-2x.png"

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -8,14 +8,16 @@
              xmlns:controls="clr-namespace:Nitrox.Launcher.Models.Design.Controls"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="600" d:DataContext="{x:Static launcher:DesignData.ManageServerViewModel}"
              x:Class="Nitrox.Launcher.Views.ManageServerView">
-    <StackPanel VerticalAlignment="Stretch" Classes="form">
+    <Grid RowDefinitions="Auto,*">
         
-        <Button Background="Transparent" Command="{Binding BackCommand}">
-            <Image HorizontalAlignment="Left" Source="/Assets/Images/world-manager/back-2x.png" Width="24" Height="24" />
-        </Button>
-        <TextBlock Classes="header" Text="{Binding ServerName}" />
-
-        <ScrollViewer VerticalScrollBarVisibility="Auto"> <!-- TODO: Fix Scroll bar functionality -->
+        <StackPanel Classes="form" Margin="0 0 0 26">
+            <Button Background="Transparent" Command="{Binding BackCommand}">
+                <Image HorizontalAlignment="Left" Source="/Assets/Images/world-manager/back-2x.png" Width="24" Height="24" />
+            </Button>
+            <TextBlock Classes="header" Text="{Binding ServerName}" />
+        </StackPanel>
+        
+        <ScrollViewer Grid.Row="1">
             <StackPanel VerticalAlignment="Stretch">
                 <StackPanel.Styles>
                     <Style Selector="ScrollViewer > StackPanel > StackPanel, ScrollViewer > StackPanel > Grid">
@@ -135,5 +137,5 @@
                 
             </StackPanel>
         </ScrollViewer>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -37,25 +37,25 @@
                     </Style>
                 </StackPanel.Styles>
                 <Panel>
-                    <StackPanel Orientation="Horizontal" IsVisible="{Binding ServerIsOnline}">
+                    <StackPanel Orientation="Horizontal" IsVisible="{Binding Server.IsOnline}">
                         <Ellipse Margin="0 0 6 0" Fill="#38C149" />
-                        <TextBlock IsVisible="{Binding ServerIsOnline}" Text="Online" />
+                        <TextBlock IsVisible="{Binding Server.IsOnline}" Text="Online" />
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" IsVisible="{Binding !ServerIsOnline}">
+                    <StackPanel Orientation="Horizontal" IsVisible="{Binding !Server.IsOnline}">
                         <Ellipse Margin="0 0 6 0" Fill="#FF5E57" />
-                        <TextBlock IsVisible="{Binding !ServerIsOnline}" Text="Offline" />
+                        <TextBlock IsVisible="{Binding !Server.IsOnline}" Text="Offline" />
                     </StackPanel>
                 </Panel>
-                <TextBlock Text="{Binding ServerGameMode, Converter={converters:ToStringConverter}}" />
+                <TextBlock Text="{Binding Server.GameMode, Converter={converters:ToStringConverter}}" />
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="{Binding ServerPlayerCount}" />
+                    <TextBlock Text="{Binding Server.Players}" />
                     <TextBlock Text="/" />
-                    <TextBlock Text="{Binding ServerPlayerLimit}" />
+                    <TextBlock Text="{Binding Server.MaxPlayers}" />
                     <TextBlock Margin="6 0 0 0" Text="playing" />
                 </StackPanel>
             </StackPanel>
             
-            <TextBlock Classes="header" Text="{Binding ServerName}" />
+            <TextBlock Classes="header" Text="{Binding Server.Name}" />
         </StackPanel>
         
         <ScrollViewer Grid.Row="1">
@@ -69,29 +69,29 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
+                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding Server.Name}" />
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"/>
+                        <TextBox Watermark="Server password" Text="{Binding Server.Password}" PasswordChar="●"/>
                     </StackPanel>
                 </Grid>
         
                 <StackPanel>
                     <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" />
-                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding ServerGameMode, Mode=TwoWay}" />
+                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding Server.GameMode, Mode=TwoWay}" />
                 </StackPanel>
                 
                 <Grid ColumnDefinitions="*,30,*,30,*">
                     <StackPanel>
                         <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server seed" Text="{Binding ServerSeed}" />
+                        <TextBox Watermark="Server seed" Text="{Binding Server.Seed}" />
                     </StackPanel>
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Might need to use converters here -->
-                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerDefaultPerms}">
+                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding Server.DefaultPlayerPerm}">
                             <ComboBoxItem Content="Player" Tag="PLAYER"/>
                             <ComboBoxItem Content="Operator" Tag="OPERATOR"/>
                             <ComboBoxItem Content="Admin" Tag="ADMIN"/>
@@ -100,7 +100,7 @@
                     <StackPanel Grid.Column="4">
                         <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Handle values other than the preset ones by binding data directly to the ComboBox's TextBox -->
-                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerAutoSaveInterval}">
+                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding Server.AutoSaveInterval}">
                             <ComboBoxItem Content="60s" Tag="60"/>
                             <ComboBoxItem Content="120s" Tag="120"/>
                             <ComboBoxItem Content="240s" Tag="240"/>
@@ -113,12 +113,12 @@
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerPlayerLimit, FallbackValue=100}" />
+                        <TextBox Watermark="Enter a player limit" Text="{Binding Server.MaxPlayers, FallbackValue=100}" />
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"/>
+                        <TextBox Watermark="Enter a port number" Text="{Binding Server.Port, FallbackValue=11000}"/>
                     </StackPanel>
                 </Grid>
                 
@@ -134,15 +134,15 @@
                         </StackPanel.Styles> 
                         <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding AutoPortForward}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding Server.AutoPortForward}" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding AllowLanDiscovery}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding Server.AllowLanDiscovery}" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Enable Commands"/>
-                            <CheckBox Classes="switch" IsChecked="{Binding EnableCommands}" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding Server.AllowCommands}" HorizontalAlignment="Right"/>
                         </Grid>
                     </StackPanel>
                 </StackPanel>
@@ -183,10 +183,10 @@
                             <RadioButton >External console</RadioButton>
                         </StackPanel>
                         
-                        <Button Grid.Column="1" Classes="nitrox abort big" IsVisible="{Binding ServerIsOnline}"
+                        <Button Grid.Column="1" Classes="nitrox abort big" IsVisible="{Binding Server.IsOnline}"
                                 VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
                                 design:NitroxAttached.Text="STOP SERVER" Command="{Binding Server.StopCommand}" /> <!-- Sort of works -->
-                        <Button Grid.Column="1" Classes="nitrox primary big" IsVisible="{Binding !ServerIsOnline}"
+                        <Button Grid.Column="1" Classes="nitrox primary big" IsVisible="{Binding !Server.IsOnline}"
                                 VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
                                 design:NitroxAttached.Text="START SERVER" design:NitroxAttached.Subtext="MULTIPLAYER" Command="{Binding Server.StartCommand}" /> <!-- Sort of works -->
                     </Grid>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -107,26 +107,23 @@
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
-                        <!-- TODO: Might need to use converters here -->
                         <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch"
-                                  ItemsSource="{Binding PlayerPerms, StringFormat='{}{0} THIS DOESN\'T WORK'}"
+                                  ItemsSource="{Binding PlayerPerms}"
                                   SelectedValue="{Binding ServerDefaultPlayerPerm}"
-                                  IsEnabled="{Binding !ServerIsOnline}"> <!-- StringFormat={}{0.ToLower()} -->
+                                  IsEnabled="{Binding !ServerIsOnline}">
+                            <ComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock Text="{Binding Converter={converters:ToStringConverter}}" />
+                                </DataTemplate>
+                            </ComboBox.ItemTemplate>
                         </ComboBox>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="4">
-                        <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
-                        <!-- TODO: Handle values other than the preset ones by binding data directly to the ComboBox's TextBox -->
-                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch"
-                                  SelectedValue="{Binding ServerAutoSaveInterval}"
-                                  IsEnabled="{Binding !ServerIsOnline}">
-                            <ComboBoxItem Content="60s" Tag="60"/>
-                            <ComboBoxItem Content="120s" Tag="120"/>
-                            <ComboBoxItem Content="240s" Tag="240"/>
-                            <ComboBoxItem Content="300s" Tag="300"/>
-                            <ComboBoxItem Content="600s" Tag="600"/>
-                        </ComboBox>
+                        <TextBlock Text="AUTO SAVE INTERVAL (s)" FontSize="10" Opacity=".5" FontWeight="700" />
+                        <TextBox Watermark="Autosave interval" FontSize="13" HorizontalAlignment="Stretch"
+                                 Text="{Binding ServerAutoSaveInterval}"
+                                 IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                 </Grid>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -122,8 +122,9 @@
                     <StackPanel Grid.Column="4">
                         <TextBlock Text="AUTO SAVE INTERVAL (s)" FontSize="10" Opacity=".5" FontWeight="700" />
                         <TextBox Watermark="Autosave interval" FontSize="13" HorizontalAlignment="Stretch"
-                                 Text="{Binding ServerAutoSaveInterval}"
-                                 IsEnabled="{Binding !ServerIsOnline}"/>
+                                 Text="{Binding ServerAutoSaveInterval, Converter={converters:IntToStringConverter}}"
+                                 IsEnabled="{Binding !ServerIsOnline}"
+                                 KeyDown="InputElement_OnKeyDown" MaxLength="9"/>
                     </StackPanel>
                 </Grid>
                 
@@ -131,13 +132,15 @@
                     <StackPanel>
                         <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Enter a player limit" Text="{Binding ServerMaxPlayers, FallbackValue=100}"
-                                 IsEnabled="{Binding !ServerIsOnline}"/>
+                                 IsEnabled="{Binding !ServerIsOnline}"
+                                 KeyDown="InputElement_OnKeyDown" MaxLength="9"/>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"
-                                 IsEnabled="{Binding !ServerIsOnline}"/>
+                                 IsEnabled="{Binding !ServerIsOnline}"
+                                 KeyDown="InputElement_OnKeyDown" MaxLength="9"/>
                     </StackPanel>
                 </Grid>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -15,38 +15,41 @@
         </Button>
         <TextBlock Classes="header" Text="{Binding ServerName}" />
 
-        <ScrollViewer VerticalScrollBarVisibility="Auto"> <!-- Scroll bar functionality doesn't work yet -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto"> <!-- TODO: Fix Scroll bar functionality -->
             <StackPanel VerticalAlignment="Stretch">
                 <StackPanel.Styles>
-                    <Style Selector="StackPanel > StackPanel, StackPanel > Grid">
-                        <Setter Property="Margin" Value="0,0,0,42"/>
+                    <Style Selector="ScrollViewer > StackPanel > StackPanel, ScrollViewer > StackPanel > Grid">
+                        <Setter Property="Margin" Value="0 0 0 42"/>
+                    </Style>
+                    <Style Selector="ScrollViewer > StackPanel > Grid > StackPanel > TextBlock, ScrollViewer > StackPanel > StackPanel > TextBlock">
+                        <Setter Property="Margin" Value="0 0 0 11"/>
                     </Style>
                 </StackPanel.Styles>
                 
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
-                        <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
-                        <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"/>
                     </StackPanel>
                 </Grid>
         
                 <StackPanel>
-                    <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                    <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" />
                     <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding ServerGameMode, Mode=TwoWay}" />
                 </StackPanel>
                 
                 <Grid ColumnDefinitions="*,30,*,30,*">
                     <StackPanel>
-                        <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Server seed" Text="{Binding ServerSeed}" />
                     </StackPanel>
                     <StackPanel Grid.Column="2">
-                        <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" Margin="0 0 0 11" />
+                        <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
                         <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
                             <ComboBoxItem Content="Player" IsSelected="True"/>
                             <ComboBoxItem Content="Operator"/>
@@ -54,7 +57,7 @@
                         </ComboBox>
                     </StackPanel>
                     <StackPanel Grid.Column="4">
-                        <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" Margin="0 0 0 11" />
+                        <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
                         <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch">
                             <ComboBoxItem Content="60s"/>
                             <ComboBoxItem Content="120s" IsSelected="True"/>
@@ -66,34 +69,36 @@
                 
                 <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
-                        <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Enter a player limit" Text="{Binding ServerPlayerLimit, FallbackValue=100}" />
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
-                        <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"/>
                     </StackPanel>
                 </Grid>
                 
-                <!-- TODO: Fix Spacing and alignment here. Each row (grid) is supposed to be spaced apart by 31 pixels -->
                 <StackPanel>
-                    <TextBlock Text="OPTIONS" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 25.5" />
+                    <TextBlock Text="OPTIONS" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 15" />
                     <StackPanel>
                         <StackPanel.Styles>
-                            <Style Selector="StackPanel > TextBlock">
-                                <Setter Property="Margin" Value="0 0 0 11"/>
+                            <Style Selector="StackPanel > Grid">
+                                <Setter Property="Margin" Value="0 0 0 20"/>
+                            </Style>
+                            <Style Selector="Grid > TextBlock">
                                 <Setter Property="FontSize" Value="16"/>
                                 <Setter Property="FontWeight" Value="400"/>
+                                <Setter Property="VerticalAlignment" Value="Center"/>
                             </Style>
                         </StackPanel.Styles> 
                         <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                            <CheckBox Classes="switch" IsChecked="True"  HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="True" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                            <CheckBox Classes="switch"  HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Enable Commands"/>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -101,19 +101,17 @@
                     <StackPanel>
                         <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" />
                         <TextBox Watermark="Server seed" Text="{Binding ServerSeed}"
-                                 MaxLength="10" IsEnabled="{Binding !ServerIsOnline}"/>
+                                 MaxLength="10" IsEnabled="{Binding !ServerIsOnline}"
+                                 IsReadOnly="{Binding !Server.IsNewServer}"/>
                     </StackPanel>
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Might need to use converters here -->
-                        <ComboBox x:Name="PlayerPermsComboBox" PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch"
-                                  ItemsSource="{x:Type models:PlayerPermissions}"
+                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch"
+                                  ItemsSource="{Binding PlayerPerms, StringFormat='{}{0} THIS DOESN\'T WORK'}"
                                   SelectedValue="{Binding ServerDefaultPlayerPerm}"
-                                  IsEnabled="{Binding !ServerIsOnline}">
-                            <!--ComboBoxItem Content="Player" Tag="PLAYER"/>
-                            <ComboBoxItem Content="Operator" Tag="OPERATOR"/>
-                            <ComboBoxItem Content="Admin" Tag="ADMIN"/-->
+                                  IsEnabled="{Binding !ServerIsOnline}"> <!-- StringFormat={}{0.ToLower()} -->
                         </ComboBox>
                     </StackPanel>
                     

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -16,19 +16,19 @@
         <TextBlock Classes="header" Text="{Binding ServerName}" />
 
         <ScrollViewer VerticalScrollBarVisibility="Auto"> <!-- Scroll bar functionality doesn't work yet -->
-            <StackPanel VerticalAlignment="Stretch" Classes="form">
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition />
-                        <ColumnDefinition Width="30" />
-                        <ColumnDefinition />
-                    </Grid.ColumnDefinitions>
-
+            <StackPanel VerticalAlignment="Stretch">
+                <StackPanel.Styles>
+                    <Style Selector="StackPanel > StackPanel, StackPanel > Grid">
+                        <Setter Property="Margin" Value="0,0,0,42"/>
+                    </Style>
+                </StackPanel.Styles>
+                
+                <Grid ColumnDefinitions="*,30,*">
                     <StackPanel>
                         <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
                         <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
                     </StackPanel>
-            
+                    
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
                         <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"/>
@@ -36,12 +36,72 @@
                 </Grid>
         
                 <StackPanel>
-                    <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Margin="0 0 0 11" />
+                    <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
                     <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding ServerGameMode, Mode=TwoWay}" />
                 </StackPanel>
+                
+                <Grid ColumnDefinitions="*,30,*,30,*">
+                    <StackPanel>
+                        <TextBlock Text="SEED" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBox Watermark="Server seed" Text="{Binding ServerSeed}" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" Margin="0 0 0 11" />
+                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                            <ComboBoxItem Content="Player" IsSelected="True"/>
+                            <ComboBoxItem Content="Operator"/>
+                            <ComboBoxItem Content="Admin"/>
+                        </ComboBox>
+                    </StackPanel>
+                    <StackPanel Grid.Column="4">
+                        <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" Margin="0 0 0 11" />
+                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch">
+                            <ComboBoxItem Content="60s"/>
+                            <ComboBoxItem Content="120s" IsSelected="True"/>
+                            <ComboBoxItem Content="180s"/>
+                            <ComboBoxItem Content="240s"/>
+                        </ComboBox>
+                    </StackPanel>
+                </Grid>
+                
+                <Grid ColumnDefinitions="*,30,*">
+                    <StackPanel>
+                        <TextBlock Text="PLAYER LIMIT" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBox Watermark="Enter a player limit" Text="{Binding ServerPlayerLimit, FallbackValue=100}" />
+                    </StackPanel>
+                    
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="SERVER PORT" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBox Watermark="Enter a port number" Text="{Binding ServerPort, FallbackValue=11000}"/>
+                    </StackPanel>
+                </Grid>
+                
+                <StackPanel>
+                    <TextBlock Text="OPTIONS" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 25.5" />
+                    <StackPanel >
+                        <StackPanel.Styles>
+                            <Style Selector="DockPanel">
+                                <Setter Property="Margin" Value="0,0,0,31"/>
+                            </Style>
+                            <Style Selector="TextBlock">
+                                <Setter Property="DockPanel.Dock" Value="Left"/>
+                                <Setter Property="FontSize" Value="16"/>
+                                <Setter Property="FontWeight" Value="400"/>
+                            </Style>
+                        </StackPanel.Styles> 
+                        <DockPanel>
+                            <TextBlock Text="Enable auto port forwarding"/>
+                        </DockPanel>
+                        <DockPanel>
+                            <TextBlock Text="Allow LAN Discovery"/>
+                        </DockPanel>
+                        <DockPanel>
+                            <TextBlock Text="Enable Commands"/>
+                        </DockPanel>
+                    </StackPanel>
+                </StackPanel>
+                
             </StackPanel>
         </ScrollViewer>
-        
-        
     </StackPanel>
 </UserControl>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -6,23 +6,61 @@
              xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design"
              xmlns:models="clr-namespace:Nitrox.Launcher.Models"
              xmlns:controls="clr-namespace:Nitrox.Launcher.Models.Design.Controls"
+             xmlns:converters="clr-namespace:Nitrox.Launcher.Models.Converters"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="600" d:DataContext="{x:Static launcher:DesignData.ManageServerViewModel}"
              x:Class="Nitrox.Launcher.Views.ManageServerView">
-    <Grid RowDefinitions="Auto,*">
+    <Grid RowDefinitions="Auto,*,Auto">
         
         <StackPanel Classes="form" Margin="0 0 0 26">
             <Button Background="Transparent" Command="{Binding BackCommand}">
                 <Image HorizontalAlignment="Left" Source="/Assets/Images/world-manager/back-2x.png" Width="24" Height="24" />
             </Button>
+            
+            <StackPanel Width="223" Orientation="Horizontal" HorizontalAlignment="Left" Classes="description" Margin="0 0 0 10">
+                <StackPanel.Styles>
+                    <Style Selector="StackPanel.description > :is(Control)">
+                        <Setter Property="VerticalAlignment" Value="Center" />
+                        <Setter Property="Margin" Value="6 0" />
+                    </Style>
+                    <Style Selector="StackPanel.description > :is(Control):nth-child(1)">
+                        <Setter Property="Margin" Value="0 0 6 0" />
+                    </Style>
+                    <Style Selector="StackPanel.description > :is(Control):nth-last-child(1)">
+                        <Setter Property="Margin" Value="6 0 0 0" />
+                    </Style>
+                    <Style Selector="Ellipse">
+                        <Setter Property="Height" Value="6" />
+                        <Setter Property="Width" Value="6" />
+                    </Style>
+                    <Style Selector="TextBlock">
+                        <Setter Property="Opacity" Value="0.5" />
+                    </Style>
+                </StackPanel.Styles>
+                <Panel>
+                    <StackPanel Orientation="Horizontal" IsVisible="{Binding ServerIsOnline}">
+                        <Ellipse Margin="0 0 6 0" Fill="#38C149" />
+                        <TextBlock IsVisible="{Binding ServerIsOnline}" Text="Online" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" IsVisible="{Binding !ServerIsOnline}">
+                        <Ellipse Margin="0 0 6 0" Fill="#FF5E57" />
+                        <TextBlock IsVisible="{Binding !ServerIsOnline}" Text="Offline" />
+                    </StackPanel>
+                </Panel>
+                <TextBlock Text="{Binding ServerGameMode, Converter={converters:ToStringConverter}}" />
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{Binding ServerPlayerCount}" />
+                    <TextBlock Text="/" />
+                    <TextBlock Text="{Binding ServerPlayerLimit}" />
+                    <TextBlock Margin="6 0 0 0" Text="playing" />
+                </StackPanel>
+            </StackPanel>
+            
             <TextBlock Classes="header" Text="{Binding ServerName}" />
         </StackPanel>
         
         <ScrollViewer Grid.Row="1">
-            <StackPanel VerticalAlignment="Stretch">
+            <StackPanel VerticalAlignment="Stretch" Spacing="42">
                 <StackPanel.Styles>
-                    <Style Selector="ScrollViewer > StackPanel > StackPanel, ScrollViewer > StackPanel > Grid">
-                        <Setter Property="Margin" Value="0 0 0 42"/>
-                    </Style>
                     <Style Selector="ScrollViewer > StackPanel > Grid > StackPanel > TextBlock, ScrollViewer > StackPanel > StackPanel > TextBlock">
                         <Setter Property="Margin" Value="0 0 0 11"/>
                     </Style>
@@ -52,19 +90,22 @@
                     </StackPanel>
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
-                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                            <ComboBoxItem Content="Player" IsSelected="True"/>
-                            <ComboBoxItem Content="Operator"/>
-                            <ComboBoxItem Content="Admin"/>
+                        <!-- TODO: Might need to use converters here -->
+                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerDefaultPerms}">
+                            <ComboBoxItem Content="Player" Tag="PLAYER"/>
+                            <ComboBoxItem Content="Operator" Tag="OPERATOR"/>
+                            <ComboBoxItem Content="Admin" Tag="ADMIN"/>
                         </ComboBox>
                     </StackPanel>
                     <StackPanel Grid.Column="4">
                         <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
-                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch">
-                            <ComboBoxItem Content="60s"/>
-                            <ComboBoxItem Content="120s" IsSelected="True"/>
-                            <ComboBoxItem Content="180s"/>
-                            <ComboBoxItem Content="240s"/>
+                        <!-- TODO: Handle values other than the preset ones by binding data directly to the ComboBox's TextBox -->
+                        <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch" SelectedValueBinding="{Binding ServerAutoSaveInterval}">
+                            <ComboBoxItem Content="60s" Tag="60"/>
+                            <ComboBoxItem Content="120s" Tag="120"/>
+                            <ComboBoxItem Content="240s" Tag="240"/>
+                            <ComboBoxItem Content="300s" Tag="300"/>
+                            <ComboBoxItem Content="600s" Tag="600"/>
                         </ComboBox>
                     </StackPanel>
                 </Grid>
@@ -93,15 +134,15 @@
                         </StackPanel.Styles> 
                         <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                            <CheckBox Classes="switch" IsChecked="True" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding AutoPortForward}" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                            <CheckBox Classes="switch" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding AllowLanDiscovery}" HorizontalAlignment="Right"/>
                         </Grid>
                         <Grid>
                             <TextBlock Text="Enable Commands"/>
-                            <CheckBox Classes="switch" IsChecked="True" HorizontalAlignment="Right"/>
+                            <CheckBox Classes="switch" IsChecked="{Binding EnableCommands}" HorizontalAlignment="Right"/>
                         </Grid>
                     </StackPanel>
                 </StackPanel>
@@ -134,6 +175,22 @@
                         
                     </StackPanel>
                 </StackPanel>
+                
+                <Border Background="#151516" CornerRadius="12" Height="96">
+                    <Grid ColumnDefinitions="*,*" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                        <StackPanel  HorizontalAlignment="Left" VerticalAlignment="Center" Margin="26 0">
+                            <RadioButton IsChecked="True" >Docked console</RadioButton>
+                            <RadioButton >External console</RadioButton>
+                        </StackPanel>
+                        
+                        <Button Grid.Column="1" Classes="nitrox abort big" IsVisible="{Binding ServerIsOnline}"
+                                VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
+                                design:NitroxAttached.Text="STOP SERVER" Command="{Binding Server.StopCommand}" /> <!-- Sort of works -->
+                        <Button Grid.Column="1" Classes="nitrox primary big" IsVisible="{Binding !ServerIsOnline}"
+                                VerticalAlignment="Center" HorizontalAlignment="Stretch" Margin="25 17"
+                                design:NitroxAttached.Text="START SERVER" design:NitroxAttached.Subtext="MULTIPLAYER" Command="{Binding Server.StartCommand}" /> <!-- Sort of works -->
+                    </Grid>
+                </Border>
                 
             </StackPanel>
         </ScrollViewer>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -205,7 +205,7 @@
                         <Button Classes="textimage" 
                                 design:NitroxAttached.Image="/Assets/Images/world-manager/delete-2x.png"
                                 design:NitroxAttached.Text="Delete server" Foreground="#ec1c24"
-                                Command="{Binding DeleteServerCommand}"/> <!-- IsEnabled="{Binding !ServerIsOnline}" -->
+                                Command="{Binding DeleteServerCommand}"/>
                         
                     </StackPanel>
                 </StackPanel>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -76,28 +76,29 @@
                     </StackPanel>
                 </Grid>
                 
+                <!-- TODO: Fix Spacing and alignment here. Each row (grid) is supposed to be spaced apart by 31 pixels -->
                 <StackPanel>
                     <TextBlock Text="OPTIONS" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 25.5" />
-                    <StackPanel >
+                    <StackPanel>
                         <StackPanel.Styles>
-                            <Style Selector="DockPanel">
-                                <Setter Property="Margin" Value="0,0,0,31"/>
-                            </Style>
-                            <Style Selector="TextBlock">
-                                <Setter Property="DockPanel.Dock" Value="Left"/>
+                            <Style Selector="StackPanel > TextBlock">
+                                <Setter Property="Margin" Value="0 0 0 11"/>
                                 <Setter Property="FontSize" Value="16"/>
                                 <Setter Property="FontWeight" Value="400"/>
                             </Style>
                         </StackPanel.Styles> 
-                        <DockPanel>
+                        <Grid>
                             <TextBlock Text="Enable auto port forwarding"/>
-                        </DockPanel>
-                        <DockPanel>
+                            <CheckBox Classes="switch" IsChecked="True"  HorizontalAlignment="Right"/>
+                        </Grid>
+                        <Grid>
                             <TextBlock Text="Allow LAN Discovery"/>
-                        </DockPanel>
-                        <DockPanel>
+                            <CheckBox Classes="switch"  HorizontalAlignment="Right"/>
+                        </Grid>
+                        <Grid>
                             <TextBlock Text="Enable Commands"/>
-                        </DockPanel>
+                            <CheckBox Classes="switch" IsChecked="True" HorizontalAlignment="Right"/>
+                        </Grid>
                     </StackPanel>
                 </StackPanel>
                 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -4,16 +4,44 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:launcher="clr-namespace:Nitrox.Launcher"
              xmlns:design="clr-namespace:Nitrox.Launcher.Models.Design"
+             xmlns:models="clr-namespace:Nitrox.Launcher.Models"
+             xmlns:controls="clr-namespace:Nitrox.Launcher.Models.Design.Controls"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="600" d:DataContext="{x:Static launcher:DesignData.ManageServerViewModel}"
              x:Class="Nitrox.Launcher.Views.ManageServerView">
     <StackPanel VerticalAlignment="Stretch" Classes="form">
+        
         <Button Background="Transparent" Command="{Binding BackCommand}">
             <Image HorizontalAlignment="Left" Source="/Assets/Images/world-manager/back-2x.png" Width="24" Height="24" />
         </Button>
         <TextBlock Classes="header" Text="{Binding ServerName}" />
-        <StackPanel>
-            <TextBlock Text="SERVER NAME" />
-            <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
-        </StackPanel>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto"> <!-- Scroll bar functionality doesn't work yet -->
+            <StackPanel VerticalAlignment="Stretch" Classes="form">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="30" />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel>
+                        <TextBlock Text="SERVER NAME" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBox design:NitroxAttached.Focus="" Watermark="My server" Text="{Binding ServerName}" />
+                    </StackPanel>
+            
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" Margin="0 0 0 11" />
+                        <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"/>
+                    </StackPanel>
+                </Grid>
+        
+                <StackPanel>
+                    <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Margin="0 0 0 11" />
+                    <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}" SelectedItem="{Binding ServerGameMode, Mode=TwoWay}" />
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+        
+        
     </StackPanel>
 </UserControl>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -56,12 +56,12 @@
             </StackPanel>
             
             <Grid ColumnDefinitions="*,100,100">
-                <TextBlock Classes="header" Text="{Binding ServerName}" Margin="0 0 5 0" />
+                <TextBlock Classes="header" Text="{Binding ServerName}" Foreground="White" Margin="0 0 5 0" />
                 
                 <Button Grid.Column="1" Classes="nitrox big abort"
                         Height="40" Margin="0 0 5 0" Padding="5" HorizontalAlignment="Stretch"
                         design:NitroxAttached.Text="UNDO" Command="{Binding UndoCommand}" />
-                <Button Grid.Column="2" Classes="nitrox big"
+                <Button Grid.Column="2" Classes="nitrox big primary"
                         Height="40" Margin="5 0 0 0" Padding="5" HorizontalAlignment="Stretch"
                         design:NitroxAttached.Text="SAVE" Command="{Binding SaveCommand}" />
             </Grid>
@@ -107,12 +107,13 @@
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="DEFAULT PERMISSIONS" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Might need to use converters here -->
-                        <ComboBox PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch"
-                                  SelectedValueBinding="{Binding ServerDefaultPlayerPerm}"
+                        <ComboBox x:Name="PlayerPermsComboBox" PlaceholderText="Default Perm" FontSize="13" HorizontalAlignment="Stretch"
+                                  ItemsSource="{x:Type models:PlayerPermissions}"
+                                  SelectedValue="{Binding ServerDefaultPlayerPerm}"
                                   IsEnabled="{Binding !ServerIsOnline}">
-                            <ComboBoxItem Content="Player" Tag="PLAYER"/>
+                            <!--ComboBoxItem Content="Player" Tag="PLAYER"/>
                             <ComboBoxItem Content="Operator" Tag="OPERATOR"/>
-                            <ComboBoxItem Content="Admin" Tag="ADMIN"/>
+                            <ComboBoxItem Content="Admin" Tag="ADMIN"/-->
                         </ComboBox>
                     </StackPanel>
                     
@@ -120,7 +121,7 @@
                         <TextBlock Text="AUTO SAVE INTERVAL" FontSize="10" Opacity=".5" FontWeight="700" />
                         <!-- TODO: Handle values other than the preset ones by binding data directly to the ComboBox's TextBox -->
                         <ComboBox PlaceholderText="Autosave interval" FontSize="13" HorizontalAlignment="Stretch"
-                                  SelectedValueBinding="{Binding ServerAutoSaveInterval}"
+                                  SelectedValue="{Binding ServerAutoSaveInterval}"
                                   IsEnabled="{Binding !ServerIsOnline}">
                             <ComboBoxItem Content="60s" Tag="60"/>
                             <ComboBoxItem Content="120s" Tag="120"/>

--- a/Nitrox.Launcher/Views/ManageServerView.axaml
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml
@@ -56,7 +56,9 @@
             </StackPanel>
             
             <Grid ColumnDefinitions="*,100,100">
-                <TextBlock Classes="header" Text="{Binding ServerName}" Foreground="White" Margin="0 0 5 0" />
+                <ScrollViewer Margin="0 0 10 0" PointerWheelChanged="ScrollViewer_OnPointerWheelChanged">
+                    <TextBlock Classes="header" Text="{Binding ServerName}" Foreground="White" />
+                </ScrollViewer>
                 
                 <Button Grid.Column="1" Classes="nitrox big abort"
                         Height="40" Margin="0 0 5 0" Padding="5" HorizontalAlignment="Stretch"
@@ -68,7 +70,7 @@
             
         </StackPanel>
         
-        <ScrollViewer Grid.Row="1">
+        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
             <StackPanel VerticalAlignment="Stretch" Spacing="42">
                 <StackPanel.Styles>
                     <Style Selector="ScrollViewer > StackPanel > Grid > StackPanel > TextBlock, ScrollViewer > StackPanel > StackPanel > TextBlock">
@@ -85,11 +87,11 @@
                     
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="PASSWORD" FontSize="10" FontWeight="700" Opacity=".5" />
-                        <TextBox Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"
+                        <TextBox Classes="revealPasswordButton" Watermark="Server password" Text="{Binding ServerPassword}" PasswordChar="●"
                                  IsEnabled="{Binding !ServerIsOnline}"/>
                     </StackPanel>
                 </Grid>
-        
+            
                 <StackPanel>
                     <TextBlock Text="GAMEMODE" FontSize="10" FontWeight="700" Opacity=".5" />
                     <controls:RadioButtonGroup Classes="radioGroup" Enum="{x:Type models:GameMode}"

--- a/Nitrox.Launcher/Views/ManageServerView.axaml.cs
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Input;
+﻿using Avalonia.Controls;
+using Avalonia.Input;
 using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
 
@@ -14,5 +15,20 @@ public partial class ManageServerView : RoutableViewBase<ManageServerViewModel>
     private void InputElement_OnKeyDown(object sender, KeyEventArgs e)
     {
         e.Handled = e.Key is < Key.D0 or > Key.D9;
+    }
+
+    private void ScrollViewer_OnPointerWheelChanged(object sender, PointerWheelEventArgs e)
+    {
+        // Change scroll wheel input to move scroll viewer left and right
+        ScrollViewer scrollViewer = (ScrollViewer)sender;
+        if (e.Delta.Y < 0)
+        {
+            scrollViewer.LineRight();
+        }
+        else
+        {
+            scrollViewer.LineLeft();
+        }
+        e.Handled = true;
     }
 }

--- a/Nitrox.Launcher/Views/ManageServerView.axaml.cs
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using System;
+using Avalonia.Controls;
 using Avalonia.Input;
 using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
@@ -14,6 +15,26 @@ public partial class ManageServerView : RoutableViewBase<ManageServerViewModel>
     
     private void InputElement_OnKeyDown(object sender, KeyEventArgs e)
     {
+        switch (e.Key)
+        {
+            case Key.Up:
+            case Key.Down:
+                if (sender is TextBox textBox)
+                {
+                    string previousText = textBox.Text;
+                    if (int.TryParse(textBox.Text, out int val))
+                    {
+                        val += e.Key == Key.Up ? 1 : -1;
+                    }
+                    textBox.Text = Math.Clamp(val, 0, int.MaxValue).ToString();
+                    if (textBox.Text.Length > textBox.MaxLength)
+                    {
+                        textBox.Text = previousText;
+                    }
+                }
+                break;
+        }
+
         e.Handled = e.Key is < Key.D0 or > Key.D9;
     }
 

--- a/Nitrox.Launcher/Views/ManageServerView.axaml.cs
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml.cs
@@ -1,4 +1,5 @@
-﻿using Nitrox.Launcher.ViewModels;
+﻿using Avalonia.Input;
+using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
 
 namespace Nitrox.Launcher.Views;
@@ -8,5 +9,10 @@ public partial class ManageServerView : RoutableViewBase<ManageServerViewModel>
     public ManageServerView()
     {
         InitializeComponent();
+    }
+    
+    private void InputElement_OnKeyDown(object sender, KeyEventArgs e)
+    {
+        e.Handled = e.Key is < Key.D0 or > Key.D9;
     }
 }

--- a/Nitrox.Launcher/Views/ManageServerView.axaml.cs
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using Nitrox.Launcher.Models;
-using Nitrox.Launcher.ViewModels;
+﻿using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
 
 namespace Nitrox.Launcher.Views;
@@ -10,7 +8,5 @@ public partial class ManageServerView : RoutableViewBase<ManageServerViewModel>
     public ManageServerView()
     {
         InitializeComponent();
-
-        //PlayerPermsComboBox.ItemsSource = Enum.GetValues(typeof(PlayerPermissions));
     }
 }

--- a/Nitrox.Launcher/Views/ManageServerView.axaml.cs
+++ b/Nitrox.Launcher/Views/ManageServerView.axaml.cs
@@ -1,4 +1,6 @@
-﻿using Nitrox.Launcher.ViewModels;
+﻿using System;
+using Nitrox.Launcher.Models;
+using Nitrox.Launcher.ViewModels;
 using Nitrox.Launcher.Views.Abstract;
 
 namespace Nitrox.Launcher.Views;
@@ -8,5 +10,7 @@ public partial class ManageServerView : RoutableViewBase<ManageServerViewModel>
     public ManageServerView()
     {
         InitializeComponent();
+
+        //PlayerPermsComboBox.ItemsSource = Enum.GetValues(typeof(PlayerPermissions));
     }
 }

--- a/Nitrox.Launcher/Views/ServersView.axaml
+++ b/Nitrox.Launcher/Views/ServersView.axaml
@@ -11,7 +11,7 @@
         <StackPanel VerticalAlignment="Stretch">
             <TextBlock Classes="header" Text="Servers" />
             <!-- TODO: Welcome message should be done via ViewModel binding. But for this to work we need a control that can parse markdown/rich-text as we need hyperlink support. -->
-            <TextBlock>Welcome to your Subnautica multiplayer server. For additional information and to learn more about hosting a server refer to the <TextBlock Foreground="#007BFF" Classes="link" PointerPressed="NitroxWikiTextBlock_OnPointerPressed">Nitrox Wiki</TextBlock>.</TextBlock>
+            <TextBlock>Welcome to your Subnautica multiplayer server. For additional information and to learn more about hosting a server refer to the <TextBlock Foreground="#007BFF"Classes="link" PointerPressed="NitroxWikiTextBlock_OnPointerPressed">Nitrox Wiki</TextBlock>.</TextBlock>
             <ItemsControl ItemsSource="{Binding Servers}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -50,7 +50,7 @@
                                 <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
                                     <Button Classes="nitrox abort" IsVisible="{Binding IsOnline}" design:NitroxAttached.Text="Stop" Command="{Binding StopCommand}" />
                                     <Button Classes="nitrox" IsVisible="{Binding !IsOnline}" design:NitroxAttached.Text="Start" Command="{Binding StartCommand}" />
-                                    <Button Classes="nitrox primary" design:NitroxAttached.Text="Manage" Command="{Binding ManageCommand}" CommandParameter="{Binding}" />
+                                    <Button Classes="nitrox primary" design:NitroxAttached.Text="Manage" Command="{Binding DataContext.ManageServerCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}" CommandParameter="{Binding}" />
                                 </StackPanel>
                             </DockPanel>
                         </Border>

--- a/Nitrox.Launcher/Views/ServersView.axaml
+++ b/Nitrox.Launcher/Views/ServersView.axaml
@@ -11,7 +11,7 @@
         <StackPanel VerticalAlignment="Stretch">
             <TextBlock Classes="header" Text="Servers" />
             <!-- TODO: Welcome message should be done via ViewModel binding. But for this to work we need a control that can parse markdown/rich-text as we need hyperlink support. -->
-            <TextBlock>Welcome to your Subnautica multiplayer server. For additional information and to learn more about hosting a server refer to the <TextBlock Foreground="#007BFF"Classes="link" PointerPressed="NitroxWikiTextBlock_OnPointerPressed">Nitrox Wiki</TextBlock>.</TextBlock>
+            <TextBlock>Welcome to your Subnautica multiplayer server. For additional information and to learn more about hosting a server refer to the <TextBlock Foreground="#007BFF" Classes="link" PointerPressed="NitroxWikiTextBlock_OnPointerPressed">Nitrox Wiki</TextBlock>.</TextBlock>
             <ItemsControl ItemsSource="{Binding Servers}">
                 <ItemsControl.ItemsPanel>
                     <ItemsPanelTemplate>


### PR DESCRIPTION
The goal is to copy the design of the Manage Server View from the figma file (shown below) over to the launcher.

Elements to add:

- [x] Server Status bar (Online/offline indicator, server gamemode, player count)
- [x] Server password textbox
- [x] Gamemode radio buttons
- [x] World seed textbox
- [x] Default Permissions dropdown
- [x] Autosave interval ~~dropdown~~ textbox
- [x] Player limit textbox
- [x] Server port textbox
- [x] Auto port forward switch
- [x] LAN discovery switch
- [x] Advanced settings switch (Not part of original design, but discussed in Discord server)
- [x] Enable commands switch
- [x] Open world folder button
- [x] Import backup button
- [x] Delete server button
- [x] Start server button & Docked/External console radio buttons

Things left TODO:

- [x] Finish binding data to all setting elements
- [x] Fix start/stop server button to update when clicked (it works but doesn't update until you exit and return to the view)
- [x] Fix scrollviewer
- [x] Fix issue with Nitrox Validation logic and add validation code for the new settings
- [x] Fix `IsEnabled = "false"` styles for UI elements
- [x] Implement "Save" and "Undo" buttons + a warning to save changes when leaving the view
- [x] Fix binding with combobox~~es and handle all values with AutoSaveInterval~~
- [x] Add input checks for all setting elements
- [ ] (Optional) Fix issue with light mode highlighting for ComoBox items (and improve styling code)
- [x] (Optional) Add a button to view the password in the server password textbox

![image](https://github.com/Measurity/Nitrox/assets/32976499/21025cd5-a113-4287-8f73-f1c3f4d2ee6d)

