### PR TITLE
Fix various warnings coming from .NET 9 upgrades

### DIFF
--- a/NitroxModel/CallerArgumentExpressionAttribute.cs
+++ b/NitroxModel/CallerArgumentExpressionAttribute.cs
@@ -1,3 +1,4 @@
+#if NETFRAMEWORK
 namespace System.Runtime.CompilerServices;
 
 [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
@@ -10,3 +11,4 @@ internal sealed class CallerArgumentExpressionAttribute : Attribute
 
     public string ParameterName { get; }
 }
+#endif

--- a/NitroxModel/DataStructures/GameLogic/AbsoluteEntityCell.cs
+++ b/NitroxModel/DataStructures/GameLogic/AbsoluteEntityCell.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 using BinaryPack.Attributes;
 using NitroxModel.Core;
@@ -96,7 +96,7 @@ namespace NitroxModel.DataStructures.GameLogic
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
             {
                 return false;
             }
@@ -115,8 +115,8 @@ namespace NitroxModel.DataStructures.GameLogic
         {
             unchecked
             {
-                int hash = BatchId != null ? BatchId.GetHashCode() : 0;
-                hash = (hash * 397) ^ (CellId != null ? CellId.GetHashCode() : 0);
+                int hash = BatchId != default ? BatchId.GetHashCode() : 0;
+                hash = (hash * 397) ^ (CellId != default ? CellId.GetHashCode() : 0);
                 hash = (hash * 397) ^ Level;
                 return hash;
             }

--- a/NitroxModel/DataStructures/NitroxId.cs
+++ b/NitroxModel/DataStructures/NitroxId.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Security.Permissions;
@@ -48,7 +48,6 @@ public class NitroxId : ISerializable, IEquatable<NitroxId>, IComparable<NitroxI
         guid = new Guid(bytes);
     }
 
-    [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
     public virtual void GetObjectData(SerializationInfo info, StreamingContext context)
     {
         info.AddValue("id", guid.ToByteArray());

--- a/NitroxModel/DataStructures/Optional.cs
+++ b/NitroxModel/DataStructures/Optional.cs
@@ -119,7 +119,6 @@ namespace NitroxModel.DataStructures.Util
             Value = (T)info.GetValue("value", typeof(T));
         }
 
-        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("value", Value);

--- a/NitroxModel/DataStructures/Surrogates/SerializationSurrogate.cs
+++ b/NitroxModel/DataStructures/Surrogates/SerializationSurrogate.cs
@@ -1,21 +1,22 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
-namespace NitroxModel.DataStructures.Surrogates
+namespace NitroxModel.DataStructures.Surrogates;
+
+#pragma warning disable SYSLIB0050 // Nitrox can depend on Binary serialization
+public abstract class SerializationSurrogate<T> : ISerializationSurrogate
 {
-    public abstract class SerializationSurrogate<T> : ISerializationSurrogate
+    public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)
     {
-        public void GetObjectData(object obj, SerializationInfo info, StreamingContext context)
-        {
-            GetObjectData((T)obj, info);
-        }
-
-        public object SetObjectData(object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
-        {
-            return SetObjectData((T)obj, info);
-        }
-
-        protected abstract void GetObjectData(T obj, SerializationInfo info);
-
-        protected abstract T SetObjectData(T obj, SerializationInfo info);
+        GetObjectData((T)obj, info);
     }
+
+    public object SetObjectData(object obj, SerializationInfo info, StreamingContext context, ISurrogateSelector selector)
+    {
+        return SetObjectData((T)obj, info);
+    }
+
+    protected abstract void GetObjectData(T obj, SerializationInfo info);
+
+    protected abstract T SetObjectData(T obj, SerializationInfo info);
 }
+#pragma warning restore SYSLIB0050

--- a/NitroxModel/Packets/Exceptions/UncorrelatedPacketException.cs
+++ b/NitroxModel/Packets/Exceptions/UncorrelatedPacketException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NitroxModel.Packets.Exceptions
@@ -21,12 +21,6 @@ namespace NitroxModel.Packets.Exceptions
         }
 
         public UncorrelatedPacketException(string message, Exception innerException, CorrelatedPacket invalidPacket, string expectedCorrelationId) : base(message, innerException)
-        {
-            InvalidPacket = invalidPacket;
-            ExpectedCorrelationId = expectedCorrelationId;
-        }
-
-        protected UncorrelatedPacketException(SerializationInfo info, StreamingContext context, CorrelatedPacket invalidPacket, string expectedCorrelationId) : base(info, context)
         {
             InvalidPacket = invalidPacket;
             ExpectedCorrelationId = expectedCorrelationId;

--- a/NitroxModel/Platforms/OS/Windows/Internal/Win32Native.cs
+++ b/NitroxModel/Platforms/OS/Windows/Internal/Win32Native.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -88,7 +88,6 @@ internal static class Win32Native
     }
 
     [DllImport("kernel32.dll", SetLastError = true)]
-    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
     [SuppressUnmanagedCodeSecurity]
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool CloseHandle(IntPtr hObject);

--- a/NitroxServer/Serialization/BatchCellsParser.cs
+++ b/NitroxServer/Serialization/BatchCellsParser.cs
@@ -162,7 +162,12 @@ namespace NitroxServer.Serialization
 
                 Validate.NotNull(type, $"No type or surrogate found for {componentHeader.TypeName}!");
 
-                object component = FormatterServices.GetUninitializedObject(type);
+#if NET5_0_OR_GREATER
+                object component = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(type);
+#else
+                object component = System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type);
+#endif
+
                 long startPosition = stream.Position;
                 serializer.Deserialize(stream, component, type);
 

--- a/NitroxServer/Serialization/ServerJsonSerializer.cs
+++ b/NitroxServer/Serialization/ServerJsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NitroxModel.Platforms.OS.Shared;
@@ -51,7 +51,7 @@ public class ServerJsonSerializer : IServerSerializer
     {
         stream.Position = 0;
         using JsonTextReader reader = new(new StreamReader(stream));
-        return (T)serializer.Deserialize(reader, typeof(T));
+        return serializer.Deserialize<T>(reader);
     }
 
     public T Deserialize<T>(string filePath)

--- a/NitroxServer/Serialization/ServerProtoBufSerializer.cs
+++ b/NitroxServer/Serialization/ServerProtoBufSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -40,7 +40,7 @@ public class ServerProtoBufSerializer : IServerSerializer
 
     public T Deserialize<T>(Stream stream)
     {
-        T t = (T)Activator.CreateInstance(typeof(T));
+        T t = Activator.CreateInstance<T>();
         Model.DeserializeWithLengthPrefix(stream, t, typeof(T), PrefixStyle.Base128, 0);
         return t;
     }

--- a/NitroxServer/Serialization/World/VersionMismatchException.cs
+++ b/NitroxServer/Serialization/World/VersionMismatchException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.Serialization;
 
 namespace NitroxServer.Serialization.World
@@ -7,9 +7,10 @@ namespace NitroxServer.Serialization.World
     public class VersionMismatchException : Exception
     {
         public VersionMismatchException() { }
+
         public VersionMismatchException(string message) : base(message) { }
+
         public VersionMismatchException(string message, Exception inner) : base(message, inner) { }
-        protected VersionMismatchException(SerializationInfo info, StreamingContext context) : base(info, context) { }
 
         public override string ToString()
         {


### PR DESCRIPTION
https://devblogs.microsoft.com/dotnet/binaryformatter-removed-from-dotnet-9/

Don't know if I should remove the attributes straight away or add conditional when compiled against modern .NET

First one is just a documentation attribute
https://learn.microsoft.com/en-us/dotnet/api/system.runtime.constrainedexecution.reliabilitycontractattribute?view=net-9.0

Second seems important, but it's already discouraged by Microsoft in .NET Framework
https://learn.microsoft.com/en-us/dotnet/api/system.security.permissions.securitypermissionattribute?view=net-9.0

![image](https://github.com/user-attachments/assets/936879c6-a1d9-4f43-a7ab-c1aafb6b818d)
